### PR TITLE
checkout address-book flow and order pagination fixes

### DIFF
--- a/lib/features/account/presentation/bloc/orders_bloc.dart
+++ b/lib/features/account/presentation/bloc/orders_bloc.dart
@@ -38,6 +38,8 @@ class ClearOrderMessage extends OrdersEvent {
 enum OrdersStatus { initial, loading, loaded, error }
 
 class OrdersState extends Equatable {
+  static const Object _endCursorUnchanged = Object();
+
   final OrdersStatus status;
   final List<CustomerOrder> orders;
   final int totalCount;
@@ -63,7 +65,7 @@ class OrdersState extends Equatable {
     List<CustomerOrder>? orders,
     int? totalCount,
     bool? hasNextPage,
-    String? endCursor,
+    Object? endCursor = _endCursorUnchanged,
     bool? isLoadingMore,
     String? errorMessage,
     String? statusFilter,
@@ -73,7 +75,9 @@ class OrdersState extends Equatable {
       orders: orders ?? this.orders,
       totalCount: totalCount ?? this.totalCount,
       hasNextPage: hasNextPage ?? this.hasNextPage,
-      endCursor: endCursor,
+      endCursor: identical(endCursor, _endCursorUnchanged)
+          ? this.endCursor
+          : endCursor as String?,
       isLoadingMore: isLoadingMore ?? this.isLoadingMore,
       errorMessage: errorMessage,
       statusFilter: statusFilter ?? this.statusFilter,

--- a/lib/features/account/presentation/pages/add_review_page.dart
+++ b/lib/features/account/presentation/pages/add_review_page.dart
@@ -62,8 +62,7 @@ class AddReviewPage extends StatefulWidget {
         );
         return Future.value(null);
       }
-      final client =
-          GraphQLClientProvider.authenticatedClient(authState.token);
+      final client = GraphQLClientProvider.authenticatedClient(authState.token);
       repository = AccountRepository(client: client.value);
     }
 
@@ -94,6 +93,7 @@ class _AddReviewPageState extends State<AddReviewPage> {
   final _summaryController = TextEditingController();
   final _reviewController = TextEditingController();
   int _selectedRating = 0;
+  String? _ratingErrorText;
 
   @override
   void dispose() {
@@ -106,28 +106,28 @@ class _AddReviewPageState extends State<AddReviewPage> {
   void _onSubmit() {
     final l10n = AppLocalizations.of(context)!;
 
-    if (!_formKey.currentState!.validate()) return;
-    if (_selectedRating == 0) {
-      ScaffoldMessenger.of(context)
-        ..hideCurrentSnackBar()
-        ..showSnackBar(
-          SnackBar(
-            content: Text(l10n.accountPleaseSelectRating),
-            behavior: SnackBarBehavior.floating,
-            backgroundColor: Colors.red,
-            duration: const Duration(seconds: 2),
-          ),
-        );
+    final isFormValid = _formKey.currentState!.validate();
+    final ratingError = _selectedRating == 0
+        ? l10n.accountPleaseSelectRating
+        : null;
+
+    setState(() {
+      _ratingErrorText = ratingError;
+    });
+
+    if (!isFormValid || ratingError != null) {
       return;
     }
 
-    context.read<AddReviewBloc>().add(SubmitReview(
-          productId: widget.productId,
-          title: _summaryController.text.trim(),
-          comment: _reviewController.text.trim(),
-          rating: _selectedRating,
-          name: _nickNameController.text.trim(),
-        ));
+    context.read<AddReviewBloc>().add(
+      SubmitReview(
+        productId: widget.productId,
+        title: _summaryController.text.trim(),
+        comment: _reviewController.text.trim(),
+        rating: _selectedRating,
+        name: _nickNameController.text.trim(),
+      ),
+    );
   }
 
   @override
@@ -171,7 +171,9 @@ class _AddReviewPageState extends State<AddReviewPage> {
               ..hideCurrentSnackBar()
               ..showSnackBar(
                 SnackBar(
-                  content: Text(state.successMessage ?? l10n.accountReviewSubmitted),
+                  content: Text(
+                    state.successMessage ?? l10n.accountReviewSubmitted,
+                  ),
                   backgroundColor: AppColors.successGreen,
                   behavior: SnackBarBehavior.floating,
                   duration: const Duration(seconds: 2),
@@ -192,14 +194,11 @@ class _AddReviewPageState extends State<AddReviewPage> {
                   duration: const Duration(seconds: 3),
                 ),
               );
-            context
-                .read<AddReviewBloc>()
-                .add(const ClearAddReviewMessage());
+            context.read<AddReviewBloc>().add(const ClearAddReviewMessage());
           }
         },
         builder: (context, state) {
-          final isSubmitting =
-              state.status == AddReviewStatus.submitting;
+          final isSubmitting = state.status == AddReviewStatus.submitting;
 
           return Form(
             key: _formKey,
@@ -245,6 +244,7 @@ class _AddReviewPageState extends State<AddReviewPage> {
                         _buildTextField(
                           context,
                           label: l10n.accountSummary,
+                          isRequired: true,
                           controller: _summaryController,
                           hintText: l10n.accountReviewSummaryHint,
                           maxLines: 3,
@@ -262,6 +262,7 @@ class _AddReviewPageState extends State<AddReviewPage> {
                         _buildTextField(
                           context,
                           label: l10n.accountReview,
+                          isRequired: true,
                           controller: _reviewController,
                           hintText: l10n.accountDetailedReviewHint,
                           maxLines: 5,
@@ -314,12 +315,13 @@ class _AddReviewPageState extends State<AddReviewPage> {
               color: isDark ? AppColors.neutral700 : const Color(0x1A0E1019),
             ),
             clipBehavior: Clip.antiAlias,
-            child: widget.productImageUrl != null &&
+            child:
+                widget.productImageUrl != null &&
                     widget.productImageUrl!.isNotEmpty
                 ? Image.network(
                     widget.productImageUrl!,
                     fit: BoxFit.cover,
-                    errorBuilder: (_, __, ___) => Center(
+                    errorBuilder: (context, error, stackTrace) => Center(
                       child: Icon(
                         Icons.image_not_supported_outlined,
                         size: 28,
@@ -366,16 +368,7 @@ class _AddReviewPageState extends State<AddReviewPage> {
     return Column(
       crossAxisAlignment: CrossAxisAlignment.start,
       children: [
-        // "Rating" label
-        Text(
-          l10n.accountRating,
-          style: TextStyle(
-            fontFamily: 'Roboto',
-            fontWeight: FontWeight.w400,
-            fontSize: 14,
-            color: isDark ? AppColors.neutral300 : AppColors.neutral900,
-          ),
-        ),
+        _buildFieldLabel(context, label: l10n.accountRating, isRequired: true),
         const SizedBox(height: 8),
 
         // 5 interactive stars
@@ -389,6 +382,7 @@ class _AddReviewPageState extends State<AddReviewPage> {
               onTap: () {
                 setState(() {
                   _selectedRating = starIndex;
+                  _ratingErrorText = null;
                 });
               },
               child: Padding(
@@ -398,14 +392,19 @@ class _AddReviewPageState extends State<AddReviewPage> {
                   size: 36,
                   color: isFilled
                       ? const Color(0xFFFE9A00) // status-info/500
-                      : (isDark
-                          ? AppColors.neutral600
-                          : AppColors.neutral300),
+                      : (isDark ? AppColors.neutral600 : AppColors.neutral300),
                 ),
               ),
             );
           }),
         ),
+        if (_ratingErrorText != null) ...[
+          const SizedBox(height: 8),
+          Text(
+            _ratingErrorText!,
+            style: TextStyle(fontSize: 12, color: Colors.red.shade400),
+          ),
+        ],
       ],
     );
   }
@@ -428,29 +427,7 @@ class _AddReviewPageState extends State<AddReviewPage> {
     return Column(
       crossAxisAlignment: CrossAxisAlignment.start,
       children: [
-        // Field label with optional asterisk
-        RichText(
-          text: TextSpan(
-            text: label,
-            style: TextStyle(
-              fontFamily: 'Roboto',
-              fontWeight: FontWeight.w400,
-              fontSize: 14,
-              color: isDark ? AppColors.neutral300 : AppColors.neutral900,
-            ),
-            children: isRequired
-                ? [
-                    TextSpan(
-                      text: ' *',
-                      style: TextStyle(
-                        color: Colors.red.shade400,
-                        fontWeight: FontWeight.w500,
-                      ),
-                    ),
-                  ]
-                : null,
-          ),
-        ),
+        _buildFieldLabel(context, label: label, isRequired: isRequired),
         const SizedBox(height: 8),
 
         // Text input — Figma: rounded-10, border #E5E5E5
@@ -486,28 +463,50 @@ class _AddReviewPageState extends State<AddReviewPage> {
             ),
             focusedBorder: OutlineInputBorder(
               borderRadius: BorderRadius.circular(10),
-              borderSide: BorderSide(
-                color: AppColors.primary500,
-                width: 1.5,
-              ),
+              borderSide: BorderSide(color: AppColors.primary500, width: 1.5),
             ),
             errorBorder: OutlineInputBorder(
               borderRadius: BorderRadius.circular(10),
-              borderSide: BorderSide(
-                color: Colors.red.shade400,
-                width: 1,
-              ),
+              borderSide: BorderSide(color: Colors.red.shade400, width: 1),
             ),
             focusedErrorBorder: OutlineInputBorder(
               borderRadius: BorderRadius.circular(10),
-              borderSide: BorderSide(
-                color: Colors.red.shade400,
-                width: 1.5,
-              ),
+              borderSide: BorderSide(color: Colors.red.shade400, width: 1.5),
             ),
           ),
         ),
       ],
+    );
+  }
+
+  Widget _buildFieldLabel(
+    BuildContext context, {
+    required String label,
+    bool isRequired = false,
+  }) {
+    final isDark = Theme.of(context).brightness == Brightness.dark;
+
+    return RichText(
+      text: TextSpan(
+        text: label,
+        style: TextStyle(
+          fontFamily: 'Roboto',
+          fontWeight: FontWeight.w400,
+          fontSize: 14,
+          color: isDark ? AppColors.neutral300 : AppColors.neutral900,
+        ),
+        children: isRequired
+            ? [
+                TextSpan(
+                  text: ' *',
+                  style: TextStyle(
+                    color: Colors.red.shade400,
+                    fontWeight: FontWeight.w500,
+                  ),
+                ),
+              ]
+            : null,
+      ),
     );
   }
 
@@ -528,7 +527,9 @@ class _AddReviewPageState extends State<AddReviewPage> {
           style: ElevatedButton.styleFrom(
             backgroundColor: AppColors.primary500,
             foregroundColor: AppColors.white,
-            disabledBackgroundColor: AppColors.primary500.withValues(alpha: 0.6),
+            disabledBackgroundColor: AppColors.primary500.withValues(
+              alpha: 0.6,
+            ),
             disabledForegroundColor: AppColors.white.withValues(alpha: 0.8),
             elevation: 0,
             shape: RoundedRectangleBorder(

--- a/lib/features/checkout/data/repository/checkout_repository.dart
+++ b/lib/features/checkout/data/repository/checkout_repository.dart
@@ -94,25 +94,34 @@ class CheckoutRepository {
   /// Fetch states/provinces for a specific country by its numeric ID.
   /// API: https://api-docs.bagisto.com/api/graphql-api/shop/queries/get-country-state.html
   /// Tries with countryId first, then falls back to countryCode if available
-  Future<List<BagistoCountryState>> getCountryStates(int countryId, {String? countryCode}) async {
-    debugPrint('[CheckoutRepo] getCountryStates countryId=$countryId, countryCode=$countryCode');
-    
+  Future<List<BagistoCountryState>> getCountryStates(
+    int countryId, {
+    String? countryCode,
+  }) async {
+    debugPrint(
+      '[CheckoutRepo] getCountryStates countryId=$countryId, countryCode=$countryCode',
+    );
+
     // If no valid countryId, try fallback with countryCode
     if (countryId <= 0) {
       if (countryCode != null && countryCode.isNotEmpty) {
-        debugPrint('[CheckoutRepo] countryId invalid, falling back to countryCode=$countryCode');
+        debugPrint(
+          '[CheckoutRepo] countryId invalid, falling back to countryCode=$countryCode',
+        );
         return _getCountryStatesByCode(countryCode);
       }
-      debugPrint('[CheckoutRepo] getCountryStates: invalid countryId=$countryId and no countryCode, returning empty');
+      debugPrint(
+        '[CheckoutRepo] getCountryStates: invalid countryId=$countryId and no countryCode, returning empty',
+      );
       return [];
     }
-    
+
     // Query with countryId (Int! required) — do NOT pass countryCode here
     final Map<String, dynamic> variables = {
       'countryId': countryId,
       'first': 200,
     };
-    
+
     final result = await _authedClient.query(
       QueryOptions(
         document: gql(CheckoutQueries.getCountryStates),
@@ -122,7 +131,7 @@ class CheckoutRepository {
     );
 
     debugPrint('[CheckoutRepo] getCountryStates raw result: ${result.data}');
-    
+
     if (result.hasException) {
       debugPrint('[CheckoutRepo] getCountryStates error: ${result.exception}');
       // Fallback to countryCode query if available
@@ -138,7 +147,9 @@ class CheckoutRepository {
       debugPrint('[CheckoutRepo] getCountryStates: countryStates is null');
       // Try alternative query with countryCode if available
       if (countryCode != null && countryCode.isNotEmpty && countryId <= 0) {
-        debugPrint('[CheckoutRepo] Trying alternative query with countryCode: $countryCode');
+        debugPrint(
+          '[CheckoutRepo] Trying alternative query with countryCode: $countryCode',
+        );
         return _getCountryStatesByCode(countryCode);
       }
       return [];
@@ -149,7 +160,9 @@ class CheckoutRepository {
     if (statesData is List) {
       // Direct array format: countryStates: [{id, _id, ...}, ...]
       statesList = statesData;
-      debugPrint('[CheckoutRepo] getCountryStates: direct array format, ${statesList.length} items');
+      debugPrint(
+        '[CheckoutRepo] getCountryStates: direct array format, ${statesList.length} items',
+      );
     } else if (statesData is Map) {
       // Edge/node format: countryStates: {edges: [{node: {...}}, ...]}
       final edges = statesData['edges'] as List?;
@@ -158,29 +171,36 @@ class CheckoutRepository {
             .map((edge) => edge is Map ? edge['node'] : edge)
             .where((node) => node != null)
             .toList();
-        debugPrint('[CheckoutRepo] getCountryStates: edge/node format, ${statesList.length} items');
+        debugPrint(
+          '[CheckoutRepo] getCountryStates: edge/node format, ${statesList.length} items',
+        );
       } else {
         statesList = [];
         debugPrint('[CheckoutRepo] getCountryStates: edges is null');
       }
     } else {
-      debugPrint('[CheckoutRepo] getCountryStates: unexpected format: $statesData');
+      debugPrint(
+        '[CheckoutRepo] getCountryStates: unexpected format: $statesData',
+      );
       return [];
     }
 
     return statesList
         .map(
-          (e) => BagistoCountryState.fromJson(
-            (e ?? {}) as Map<String, dynamic>,
-          ),
+          (e) =>
+              BagistoCountryState.fromJson((e ?? {}) as Map<String, dynamic>),
         )
         .toList();
   }
 
   /// Alternative: Fetch states using country code
-  Future<List<BagistoCountryState>> _getCountryStatesByCode(String countryCode) async {
-    debugPrint('[CheckoutRepo] _getCountryStatesByCode countryCode=$countryCode');
-    
+  Future<List<BagistoCountryState>> _getCountryStatesByCode(
+    String countryCode,
+  ) async {
+    debugPrint(
+      '[CheckoutRepo] _getCountryStatesByCode countryCode=$countryCode',
+    );
+
     final result = await _authedClient.query(
       QueryOptions(
         document: gql(CheckoutQueries.getCountryStatesByCode),
@@ -189,16 +209,22 @@ class CheckoutRepository {
       ),
     );
 
-    debugPrint('[CheckoutRepo] _getCountryStatesByCode raw result: ${result.data}');
-    
+    debugPrint(
+      '[CheckoutRepo] _getCountryStatesByCode raw result: ${result.data}',
+    );
+
     if (result.hasException) {
-      debugPrint('[CheckoutRepo] _getCountryStatesByCode error: ${result.exception}');
+      debugPrint(
+        '[CheckoutRepo] _getCountryStatesByCode error: ${result.exception}',
+      );
       return [];
     }
 
     final statesData = result.data?['countryStates'];
     if (statesData == null) {
-      debugPrint('[CheckoutRepo] _getCountryStatesByCode: countryStates is null');
+      debugPrint(
+        '[CheckoutRepo] _getCountryStatesByCode: countryStates is null',
+      );
       return [];
     }
 
@@ -221,9 +247,8 @@ class CheckoutRepository {
 
     return statesList
         .map(
-          (e) => BagistoCountryState.fromJson(
-            (e ?? {}) as Map<String, dynamic>,
-          ),
+          (e) =>
+              BagistoCountryState.fromJson((e ?? {}) as Map<String, dynamic>),
         )
         .toList();
   }
@@ -277,8 +302,7 @@ class CheckoutRepository {
       throw result.exception!;
     }
 
-    final edges =
-        result.data?['getCustomerAddresses']?['edges'] as List?;
+    final edges = result.data?['getCustomerAddresses']?['edges'] as List?;
     if (edges == null) return [];
 
     return edges.map((e) {
@@ -409,11 +433,63 @@ class CheckoutRepository {
     return CheckoutAddressResponse.fromJson(data);
   }
 
+  /// Save the checkout billing address into the customer's address book.
+  ///
+  /// This is used for the first logged-in checkout when the customer has no
+  /// saved addresses yet and opts into saving the entered billing address.
+  Future<void> saveCustomerAddressFromCheckout(
+    Map<String, dynamic> checkoutInput, {
+    bool defaultAddress = false,
+  }) async {
+    final input = <String, dynamic>{
+      'firstName': checkoutInput['billingFirstName']?.toString() ?? '',
+      'lastName': checkoutInput['billingLastName']?.toString() ?? '',
+      'address1': checkoutInput['billingAddress']?.toString() ?? '',
+      'city': checkoutInput['billingCity']?.toString() ?? '',
+      'state': checkoutInput['billingState']?.toString() ?? '',
+      'country': checkoutInput['billingCountry']?.toString() ?? '',
+      'postcode': checkoutInput['billingPostcode']?.toString() ?? '',
+      'phone': checkoutInput['billingPhoneNumber']?.toString() ?? '',
+      'defaultAddress': defaultAddress,
+      'useForShipping': checkoutInput['useForShipping'] == true,
+    };
+
+    final email = checkoutInput['billingEmail']?.toString() ?? '';
+    if (email.isNotEmpty) {
+      input['email'] = email;
+    }
+
+    debugPrint('[CheckoutRepo] saveCustomerAddressFromCheckout input=$input');
+
+    final result = await _authedClient.mutate(
+      MutationOptions(
+        document: gql(AccountQueries.createAddUpdateCustomerAddress),
+        variables: {'input': input},
+      ),
+    );
+
+    if (result.hasException) {
+      debugPrint(
+        '[CheckoutRepo] saveCustomerAddressFromCheckout error: ${result.exception}',
+      );
+      throw result.exception!;
+    }
+
+    final data =
+        result.data?['createAddUpdateCustomerAddress']?['addUpdateCustomerAddress']
+            as Map<String, dynamic>?;
+    if (data == null) {
+      throw Exception('Failed to save address to address book');
+    }
+  }
+
   /// Save selected shipping method
   Future<CheckoutShippingMethodResponse> saveShippingMethod(
     String shippingMethod,
   ) async {
-    debugPrint('[CheckoutRepo] saveShippingMethod: $shippingMethod (authToken present: ${_authToken != null})');
+    debugPrint(
+      '[CheckoutRepo] saveShippingMethod: $shippingMethod (authToken present: ${_authToken != null})',
+    );
     final result = await _authedClient.mutate(
       MutationOptions(
         document: gql(CheckoutMutations.createCheckoutShippingMethod),

--- a/lib/features/checkout/presentation/bloc/checkout_bloc.dart
+++ b/lib/features/checkout/presentation/bloc/checkout_bloc.dart
@@ -1,3 +1,5 @@
+import 'dart:async';
+
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:equatable/equatable.dart';
@@ -5,6 +7,7 @@ import '../../../../core/error/error_mapper.dart';
 import '../../../cart/data/models/cart_model.dart';
 import '../../data/models/checkout_model.dart';
 import '../../data/repository/checkout_repository.dart';
+import '../helpers/checkout_address_sheet_helpers.dart';
 
 // ─── Events ────────────────────────────────────────────────────────────────
 
@@ -37,17 +40,29 @@ class SyncCheckoutCart extends CheckoutEvent {
 /// Save checkout address (billing + shipping)
 class SaveCheckoutAddressEvent extends CheckoutEvent {
   final Map<String, dynamic> input;
-  const SaveCheckoutAddressEvent({required this.input});
+  final bool saveToAddressBook;
+
+  const SaveCheckoutAddressEvent({
+    required this.input,
+    this.saveToAddressBook = false,
+  });
   @override
-  List<Object?> get props => [input];
+  List<Object?> get props => [input, saveToAddressBook];
 }
 
 /// Select a saved address for checkout (logged-in user only)
 class SelectSavedAddress extends CheckoutEvent {
   final CheckoutAddress address;
-  const SelectSavedAddress({required this.address});
+  final bool useForShipping;
+  final CheckoutAddress? shippingAddress;
+
+  const SelectSavedAddress({
+    required this.address,
+    this.useForShipping = true,
+    this.shippingAddress,
+  });
   @override
-  List<Object?> get props => [address];
+  List<Object?> get props => [address, useForShipping, shippingAddress];
 }
 
 /// Select and save a shipping method → then fetch payment methods
@@ -91,6 +106,13 @@ class ResetAddressConfirmation extends CheckoutEvent {}
 
 /// Fetch countries from Bagisto API
 class FetchCountries extends CheckoutEvent {}
+
+/// Refresh the saved address list for logged-in checkout.
+class RefreshSavedAddresses extends CheckoutEvent {
+  final Completer<List<CheckoutAddress>>? completer;
+
+  const RefreshSavedAddresses({this.completer});
+}
 
 /// Fetch states for a specific country (by numeric country ID or country code)
 class FetchCountryStates extends CheckoutEvent {
@@ -328,6 +350,7 @@ class CheckoutBloc extends Bloc<CheckoutEvent, CheckoutState> {
     on<ResetAddressConfirmation>(_onResetAddressConfirmation);
     on<FetchCountries>(_onFetchCountries);
     on<FetchCountryStates>(_onFetchCountryStates);
+    on<RefreshSavedAddresses>(_onRefreshSavedAddresses);
   }
 
   /// Refresh the repo's Bearer auth token from the latest source.
@@ -344,6 +367,28 @@ class CheckoutBloc extends Bloc<CheckoutEvent, CheckoutState> {
 
   void _requestCartRefresh() {
     onCartRefreshRequested?.call();
+  }
+
+  Future<List<CheckoutAddress>> _loadSelectableAddresses() async {
+    final checkoutAddresses = await repository.getCheckoutAddresses();
+    final customerAddresses = checkoutAddresses
+        .where(
+          (address) =>
+              address.addressType != 'cart_billing' &&
+              address.addressType != 'cart_shipping',
+        )
+        .toList();
+
+    if (customerAddresses.isNotEmpty) {
+      return customerAddresses;
+    }
+
+    final accountAddresses = await repository.getCustomerAddresses();
+    if (accountAddresses.isNotEmpty) {
+      return accountAddresses;
+    }
+
+    return checkoutAddresses;
   }
 
   /// 1) Store cart, determine guest/logged-in, fetch addresses only for logged-in
@@ -835,7 +880,11 @@ class CheckoutBloc extends Bloc<CheckoutEvent, CheckoutState> {
 
     // Auto-save the newly selected address
     try {
-      final saveInput = event.address.toBillingInput(useForShipping: true);
+      final saveInput = buildSavedCheckoutAddressInput(
+        billingAddress: event.address,
+        useForShipping: event.useForShipping,
+        shippingAddress: event.shippingAddress,
+      );
       debugPrint(
         '[CheckoutBloc] Auto-saving selected address: ${event.address.fullName}',
       );
@@ -971,6 +1020,46 @@ class CheckoutBloc extends Bloc<CheckoutEvent, CheckoutState> {
     }
   }
 
+  Future<void> _onRefreshSavedAddresses(
+    RefreshSavedAddresses event,
+    Emitter<CheckoutState> emit,
+  ) async {
+    if (state.isGuest) {
+      event.completer?.complete(state.addresses);
+      return;
+    }
+
+    _refreshAuthToken();
+
+    try {
+      final refreshedAddresses = await _loadSelectableAddresses();
+      final selectedAddress = state.selectedAddress == null
+          ? null
+          : refreshedAddresses.cast<CheckoutAddress?>().firstWhere(
+              (address) => address?.id == state.selectedAddress?.id,
+              orElse: () => state.selectedAddress,
+            );
+
+      emit(
+        state.copyWith(
+          addresses: refreshedAddresses,
+          selectedAddress: selectedAddress,
+        ),
+      );
+      event.completer?.complete(refreshedAddresses);
+    } catch (e, stackTrace) {
+      event.completer?.completeError(e, stackTrace);
+      emit(
+        state.copyWith(
+          errorMessage: ErrorMapper.getUserMessage(
+            e,
+            context: 'loading saved addresses',
+          ),
+        ),
+      );
+    }
+  }
+
   /// 2) Save address → on success fetch shipping rates.
   ///
   /// For **logged-in users** the `cartToken` returned by
@@ -1015,12 +1104,34 @@ class CheckoutBloc extends Bloc<CheckoutEvent, CheckoutState> {
 
       repository.updateCartQueryToken(queryToken);
 
+      List<CheckoutAddress>? refreshedAddresses;
+      String? addressBookErrorMessage;
+      if (!state.isGuest && event.saveToAddressBook) {
+        try {
+          await repository.saveCustomerAddressFromCheckout(
+            event.input,
+            defaultAddress: state.addresses.isEmpty,
+          );
+          refreshedAddresses = await _loadSelectableAddresses();
+        } catch (e) {
+          debugPrint(
+            '[CheckoutBloc] saveCustomerAddressFromCheckout error: $e',
+          );
+          addressBookErrorMessage = ErrorMapper.getUserMessage(
+            e,
+            context: 'saving your address book',
+          );
+        }
+      }
+
       emit(
         state.copyWith(
           status: CheckoutStatus.addressSaved,
           cartToken: queryToken,
           addressConfirmed: true,
+          addresses: refreshedAddresses,
           successMessage: response.message,
+          errorMessage: addressBookErrorMessage,
         ),
       );
 

--- a/lib/features/checkout/presentation/helpers/checkout_address_sheet_helpers.dart
+++ b/lib/features/checkout/presentation/helpers/checkout_address_sheet_helpers.dart
@@ -1,0 +1,89 @@
+import '../../data/models/checkout_model.dart';
+
+String? findNewlyAddedAddressId({
+  required Set<String> previousIds,
+  required Iterable<String?> refreshedIds,
+}) {
+  for (final id in refreshedIds) {
+    if (id != null && id.isNotEmpty && !previousIds.contains(id)) {
+      return id;
+    }
+  }
+
+  return null;
+}
+
+CheckoutAddress? findNewlyAddedSelectableAddress({
+  required Set<String> previousCustomerIds,
+  required Iterable<String?> refreshedCustomerIds,
+  required List<CheckoutAddress> refreshedAddresses,
+}) {
+  final newAddressId = findNewlyAddedAddressId(
+    previousIds: previousCustomerIds,
+    refreshedIds: refreshedCustomerIds,
+  );
+
+  if (newAddressId == null) {
+    return null;
+  }
+
+  return findCheckoutAddressById(
+    addressId: newAddressId,
+    addresses: refreshedAddresses,
+  );
+}
+
+CheckoutAddress? findNewlyAddedCheckoutAddress({
+  required Set<String> previousIds,
+  required List<CheckoutAddress> refreshedAddresses,
+}) {
+  for (final address in refreshedAddresses) {
+    if (!previousIds.contains(address.id)) {
+      return address;
+    }
+  }
+
+  return null;
+}
+
+CheckoutAddress? findCheckoutAddressById({
+  required String? addressId,
+  required List<CheckoutAddress> addresses,
+}) {
+  if (addressId == null || addressId.isEmpty) {
+    return null;
+  }
+
+  for (final address in addresses) {
+    if (address.id == addressId) {
+      return address;
+    }
+  }
+
+  return null;
+}
+
+Map<String, dynamic> buildSavedCheckoutAddressInput({
+  required CheckoutAddress billingAddress,
+  required bool useForShipping,
+  CheckoutAddress? shippingAddress,
+}) {
+  final input = billingAddress.toBillingInput(useForShipping: useForShipping);
+
+  if (!useForShipping && shippingAddress != null) {
+    input.addAll({
+      'shippingFirstName': shippingAddress.firstName,
+      'shippingLastName': shippingAddress.lastName,
+      'shippingEmail': shippingAddress.email ?? '',
+      'shippingCompanyName': shippingAddress.companyName ?? '',
+      'shippingAddress': shippingAddress.address,
+      'shippingCity': shippingAddress.city,
+      'shippingCountry': shippingAddress.country ?? '',
+      'shippingState': shippingAddress.state ?? '',
+      'shippingPostcode': shippingAddress.postcode ?? '',
+      'shippingPhoneNumber': shippingAddress.phone ?? '',
+    });
+  }
+
+  return input;
+}

--- a/lib/features/checkout/presentation/pages/checkout_page.dart
+++ b/lib/features/checkout/presentation/pages/checkout_page.dart
@@ -1,16 +1,24 @@
+import 'dart:async';
+
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:cached_network_image/cached_network_image.dart';
+import '../../../../core/graphql/graphql_client.dart';
 import '../../../../core/currency/currency_formatter.dart';
 import '../../../../core/theme/app_theme.dart';
 import '../../../../core/widgets/selection_sheet.dart';
 import '../../../../l10n/app_localizations.dart';
+import '../../../account/data/repository/account_repository.dart';
+import '../../../account/presentation/bloc/address_book_bloc.dart';
+import '../../../account/presentation/pages/add_address_page.dart';
 import '../../../cart/data/models/cart_model.dart';
 import '../../../cart/presentation/bloc/cart_bloc.dart';
 import '../../../auth/presentation/bloc/auth_bloc.dart';
 import '../../data/models/checkout_model.dart';
 import '../../data/repository/checkout_repository.dart';
 import '../bloc/checkout_bloc.dart';
+import '../helpers/checkout_address_sheet_helpers.dart';
+import '../widgets/checkout_address_selection_sheet.dart';
 import 'thankyou_page.dart';
 
 class CheckoutPage extends StatelessWidget {
@@ -80,6 +88,7 @@ class _CheckoutPageView extends StatefulWidget {
 class _CheckoutPageViewState extends State<_CheckoutPageView> {
   final TextEditingController _couponController = TextEditingController();
   bool _useSameAddress = true;
+  bool _saveToAddressBook = true;
 
   bool _requiresShipping(CheckoutState state) => !state.isVirtualOnly;
 
@@ -88,6 +97,9 @@ class _CheckoutPageViewState extends State<_CheckoutPageView> {
 
   bool _showsSeparateShippingForm(CheckoutState state) =>
       _requiresShipping(state) && !_useSameAddress;
+
+  bool _shouldOfferSaveToAddressBook(CheckoutState state) =>
+      !state.isGuest && state.addresses.isEmpty;
 
   // Local selection state for immediate UI response
   String? _selectedShippingMethod;
@@ -141,6 +153,157 @@ class _CheckoutPageViewState extends State<_CheckoutPageView> {
       return false;
     }
     return cartState.isGuest;
+  }
+
+  CheckoutAddress? _currentBillingAddress(CheckoutState state) {
+    return _selectedBillingAddress ?? state.selectedAddress;
+  }
+
+  CheckoutAddress? _currentShippingAddress(CheckoutState state) {
+    if (state.addresses.isEmpty) return null;
+
+    return _selectedShippingAddress ??
+        (state.addresses.length > 1
+            ? state.addresses[1]
+            : state.addresses.first);
+  }
+
+  Future<List<CheckoutAddress>> _refreshSavedAddresses(
+    CheckoutBloc bloc,
+  ) async {
+    final completer = Completer<List<CheckoutAddress>>();
+    bloc.add(RefreshSavedAddresses(completer: completer));
+    return completer.future;
+  }
+
+  AccountRepository? _buildCheckoutAccountRepository(BuildContext context) {
+    final token = context.read<CheckoutBloc>().getLatestAuthToken?.call();
+    if (token == null || token.isEmpty) {
+      debugPrint(
+        '[CheckoutPage] Unable to open add-address flow: missing auth token',
+      );
+      return null;
+    }
+
+    final client = GraphQLClientProvider.authenticatedClient(token).value;
+    return AccountRepository(client: client);
+  }
+
+  Future<Set<String>?> _loadCustomerAddressIds(
+    AccountRepository repository,
+  ) async {
+    try {
+      final addresses = await repository.getCustomerAddresses(first: 100);
+      return addresses
+          .map((address) => address.id)
+          .whereType<String>()
+          .where((id) => id.isNotEmpty)
+          .toSet();
+    } catch (_) {
+      return null;
+    }
+  }
+
+  void _applySavedAddressSelection(
+    CheckoutBloc bloc,
+    CheckoutState state, {
+    required CheckoutAddress address,
+    required bool isBilling,
+  }) {
+    setState(() {
+      if (isBilling) {
+        _selectedBillingAddress = address;
+      } else {
+        _selectedShippingAddress = address;
+      }
+    });
+
+    if (isBilling) {
+      final useForShipping = _usesBillingAsShipping(state);
+      final shippingAddress = useForShipping
+          ? null
+          : _currentShippingAddress(state);
+      bloc.add(
+        SelectSavedAddress(
+          address: address,
+          useForShipping: useForShipping,
+          shippingAddress: shippingAddress,
+        ),
+      );
+      return;
+    }
+
+    if (!state.addressConfirmed) {
+      return;
+    }
+
+    final billingAddress = _currentBillingAddress(state);
+    if (billingAddress == null) {
+      return;
+    }
+
+    bloc.add(
+      SelectSavedAddress(
+        address: billingAddress,
+        useForShipping: false,
+        shippingAddress: address,
+      ),
+    );
+  }
+
+  Future<void> _openAddAddressFromSheet({
+    required NavigatorState navigator,
+    required AccountRepository repository,
+    required CheckoutBloc checkoutBloc,
+    required bool isBilling,
+  }) async {
+    final existingCustomerIds = await _loadCustomerAddressIds(repository);
+    final created = await navigator.push<bool>(
+      MaterialPageRoute(
+        builder: (_) => RepositoryProvider.value(
+          value: repository,
+          child: BlocProvider(
+            create: (_) => AddressBookBloc(repository: repository),
+            child: const AddAddressPage(),
+          ),
+        ),
+      ),
+    );
+
+    if (!mounted || created != true) {
+      return;
+    }
+
+    try {
+      final refreshedAddresses = await _refreshSavedAddresses(checkoutBloc);
+      if (!mounted) return;
+
+      final refreshedCustomerIds = await _loadCustomerAddressIds(repository);
+      if (!mounted ||
+          existingCustomerIds == null ||
+          refreshedCustomerIds == null) {
+        return;
+      }
+
+      final newAddress = findNewlyAddedSelectableAddress(
+        previousCustomerIds: existingCustomerIds,
+        refreshedCustomerIds: refreshedCustomerIds,
+        refreshedAddresses: refreshedAddresses,
+      );
+
+      if (newAddress == null) {
+        return;
+      }
+
+      _applySavedAddressSelection(
+        checkoutBloc,
+        checkoutBloc.state,
+        address: newAddress,
+        isBilling: isBilling,
+      );
+    } catch (_) {
+      // CheckoutBloc emits the user-facing error state.
+    }
   }
 
   @override
@@ -392,12 +555,13 @@ class _CheckoutPageViewState extends State<_CheckoutPageView> {
     }
 
     // Address confirmed → Figma-exact card
-    if (state.addressConfirmed && state.selectedAddress != null) {
+    final billingAddress = _currentBillingAddress(state);
+    if (state.addressConfirmed && billingAddress != null) {
       return _buildAddressCard(
         context: context,
         state: state,
         label: AppLocalizations.of(context)!.checkoutBillingTo,
-        address: state.selectedAddress!,
+        address: billingAddress,
         onChangePressed: () =>
             _showChangeAddressFlow(context, state, isBilling: true),
         showSameAddressCheckbox: !state.isVirtualOnly,
@@ -411,13 +575,12 @@ class _CheckoutPageViewState extends State<_CheckoutPageView> {
 
     // Logged-in with saved addresses (not yet confirmed)
     if (state.addresses.isNotEmpty) {
-      final displayAddr = _selectedBillingAddress ?? state.selectedAddress;
-      if (displayAddr != null) {
+      if (billingAddress != null) {
         return _buildAddressCardWithConfirm(
           context: context,
           state: state,
           label: AppLocalizations.of(context)!.checkoutBillingTo,
-          address: displayAddr,
+          address: billingAddress,
           onChangePressed: () =>
               _showAddressSelectionSheet(context, state, isBilling: true),
           showSameAddressCheckbox: !state.isVirtualOnly,
@@ -447,17 +610,13 @@ class _CheckoutPageViewState extends State<_CheckoutPageView> {
     if (state.isGuest) {
       return _buildGuestShippingForm(context, state);
     }
-    if (state.addresses.isNotEmpty) {
-      final displayAddr =
-          _selectedShippingAddress ??
-          (state.addresses.length > 1
-              ? state.addresses[1]
-              : state.addresses.first);
+    final shippingAddress = _currentShippingAddress(state);
+    if (shippingAddress != null) {
       return _buildAddressCard(
         context: context,
         state: state,
         label: AppLocalizations.of(context)!.checkoutDeliveredTo,
-        address: displayAddr,
+        address: shippingAddress,
         onChangePressed: () =>
             _showAddressSelectionSheet(context, state, isBilling: false),
         showSameAddressCheckbox: false,
@@ -727,14 +886,16 @@ class _CheckoutPageViewState extends State<_CheckoutPageView> {
     CheckoutState state, {
     required bool isBilling,
   }) {
+    final pageContext = context;
     final addresses = state.addresses;
     if (addresses.isEmpty) return;
 
-    final isDark = Theme.of(context).brightness == Brightness.dark;
-    final bloc = context.read<CheckoutBloc>();
+    final isDark = Theme.of(pageContext).brightness == Brightness.dark;
+    final checkoutBloc = pageContext.read<CheckoutBloc>();
+    final pageNavigator = Navigator.of(pageContext);
 
     showModalBottomSheet(
-      context: context,
+      context: pageContext,
       isScrollControlled: true,
       backgroundColor: isDark ? AppColors.neutral900 : AppColors.white,
       shape: const RoundedRectangleBorder(
@@ -746,143 +907,49 @@ class _CheckoutPageViewState extends State<_CheckoutPageView> {
           maxChildSize: 0.85,
           minChildSize: 0.3,
           expand: false,
-          builder: (context, scrollController) {
-            return Padding(
-              padding: const EdgeInsets.all(20),
-              child: Column(
-                crossAxisAlignment: CrossAxisAlignment.start,
-                children: [
-                  Center(
-                    child: Container(
-                      width: 40,
-                      height: 4,
-                      margin: const EdgeInsets.only(bottom: 16),
-                      decoration: BoxDecoration(
-                        color: isDark
-                            ? AppColors.neutral700
-                            : AppColors.neutral300,
-                        borderRadius: BorderRadius.circular(2),
-                      ),
-                    ),
-                  ),
-                  Text(
-                    isBilling
-                        ? AppLocalizations.of(
-                            context,
-                          )!.checkoutSelectBillingAddress
-                        : AppLocalizations.of(
-                            context,
-                          )!.checkoutSelectShippingAddress,
-                    style: TextStyle(
-                      fontFamily: 'Roboto',
-                      fontWeight: FontWeight.w600,
-                      fontSize: 16,
-                      color: isDark
-                          ? AppColors.neutral100
-                          : AppColors.neutral900,
-                    ),
-                  ),
-                  const SizedBox(height: 16),
-                  Expanded(
-                    child: ListView.separated(
-                      controller: scrollController,
-                      itemCount: addresses.length,
-                      separatorBuilder: (context, index) =>
-                          const SizedBox(height: 8),
-                      itemBuilder: (context, index) {
-                        final addr = addresses[index];
-                        final isSelected = isBilling
-                            ? _selectedBillingAddress?.id == addr.id
-                            : _selectedShippingAddress?.id == addr.id;
-                        return GestureDetector(
-                          onTap: () {
-                            setState(() {
-                              if (isBilling) {
-                                _selectedBillingAddress = addr;
-                                bloc.add(SelectSavedAddress(address: addr));
-                              } else {
-                                _selectedShippingAddress = addr;
-                              }
-                            });
-                            Navigator.pop(ctx);
-                          },
-                          child: Container(
-                            padding: const EdgeInsets.all(12),
-                            decoration: BoxDecoration(
-                              color: isSelected
-                                  ? AppColors.primary500.withValues(alpha: 0.05)
-                                  : (isDark
-                                        ? AppColors.neutral800
-                                        : AppColors.neutral100),
-                              border: Border.all(
-                                color: isSelected
-                                    ? AppColors.primary500
-                                    : (isDark
-                                          ? AppColors.neutral700
-                                          : AppColors.neutral200),
-                                width: isSelected ? 2 : 1,
-                              ),
-                              borderRadius: BorderRadius.circular(10),
-                            ),
-                            child: Column(
-                              crossAxisAlignment: CrossAxisAlignment.start,
-                              children: [
-                                Row(
-                                  children: [
-                                    Expanded(
-                                      child: Text(
-                                        addr.displayName,
-                                        style: TextStyle(
-                                          fontFamily: 'Roboto',
-                                          fontWeight: FontWeight.w700,
-                                          fontSize: 14,
-                                          color: isSelected
-                                              ? AppColors.primary500
-                                              : (isDark
-                                                    ? AppColors.neutral100
-                                                    : AppColors.neutral900),
-                                        ),
-                                      ),
-                                    ),
-                                    _buildGreenChip(_getAddressTypeChip(addr)),
-                                  ],
-                                ),
-                                const SizedBox(height: 4),
-                                Text(
-                                  addr.fullAddress,
-                                  style: TextStyle(
-                                    fontFamily: 'Roboto',
-                                    fontSize: 13,
-                                    color: isDark
-                                        ? AppColors.neutral400
-                                        : AppColors.neutral800,
-                                  ),
-                                ),
-                                if (addr.phone != null &&
-                                    addr.phone!.isNotEmpty) ...[
-                                  const SizedBox(height: 2),
-                                  Text(
-                                    AppLocalizations.of(
-                                      context,
-                                    )!.checkoutPhoneValue(addr.phone!),
-                                    style: TextStyle(
-                                      fontFamily: 'Roboto',
-                                      fontSize: 12,
-                                      color: isDark
-                                          ? AppColors.neutral500
-                                          : AppColors.neutral500,
-                                    ),
-                                  ),
-                                ],
-                              ],
-                            ),
-                          ),
-                        );
-                      },
-                    ),
-                  ),
-                ],
-              ),
+          builder: (sheetContext, scrollController) {
+            return CheckoutAddressSelectionSheet(
+              title: isBilling
+                  ? AppLocalizations.of(
+                      pageContext,
+                    )!.checkoutSelectBillingAddress
+                  : AppLocalizations.of(
+                      pageContext,
+                    )!.checkoutSelectShippingAddress,
+              addButtonLabel: AppLocalizations.of(
+                pageContext,
+              )!.accountAddNewAddress,
+              addresses: addresses,
+              selectedAddressId: isBilling
+                  ? _currentBillingAddress(state)?.id
+                  : _currentShippingAddress(state)?.id,
+              scrollController: scrollController,
+              addressTypeLabelBuilder: _getAddressTypeChip,
+              phoneLabelBuilder: AppLocalizations.of(
+                pageContext,
+              )!.checkoutPhoneValue,
+              onAddressSelected: (address) {
+                Navigator.pop(ctx);
+                _applySavedAddressSelection(
+                  checkoutBloc,
+                  state,
+                  address: address,
+                  isBilling: isBilling,
+                );
+              },
+              onAddNewAddress: () async {
+                final repository = _buildCheckoutAccountRepository(pageContext);
+                if (repository == null) return;
+                Navigator.pop(ctx);
+                await Future<void>.delayed(Duration.zero);
+                if (!mounted) return;
+                await _openAddAddressFromSheet(
+                  navigator: pageNavigator,
+                  repository: repository,
+                  checkoutBloc: checkoutBloc,
+                  isBilling: isBilling,
+                );
+              },
             );
           },
         );
@@ -1044,6 +1111,10 @@ class _CheckoutPageViewState extends State<_CheckoutPageView> {
               AppLocalizations.of(context)!.checkoutCompanyOptional,
             ),
             const SizedBox(height: 12),
+            if (_shouldOfferSaveToAddressBook(state)) ...[
+              _buildSaveToAddressBookCheckbox(context),
+              const SizedBox(height: 12),
+            ],
             if (_requiresShipping(state)) _buildSameAddressCheckbox(context),
             // Only show Save button here if using same address for shipping.
             // For virtual/downloadable/booking carts there is no shipping form,
@@ -1603,6 +1674,59 @@ class _CheckoutPageViewState extends State<_CheckoutPageView> {
     );
   }
 
+  Widget _buildSaveToAddressBookCheckbox(BuildContext context) {
+    final isDark = Theme.of(context).brightness == Brightness.dark;
+    return GestureDetector(
+      onTap: () {
+        setState(() => _saveToAddressBook = !_saveToAddressBook);
+      },
+      child: SizedBox(
+        height: 24,
+        child: Row(
+          children: [
+            SizedBox(
+              width: 24,
+              height: 24,
+              child: _saveToAddressBook
+                  ? Container(
+                      decoration: BoxDecoration(
+                        color: AppColors.primary500,
+                        borderRadius: BorderRadius.circular(4),
+                      ),
+                      child: const Icon(
+                        Icons.check,
+                        size: 18,
+                        color: AppColors.white,
+                      ),
+                    )
+                  : Container(
+                      decoration: BoxDecoration(
+                        border: Border.all(
+                          color: isDark
+                              ? AppColors.neutral500
+                              : AppColors.neutral400,
+                          width: 2,
+                        ),
+                        borderRadius: BorderRadius.circular(4),
+                      ),
+                    ),
+            ),
+            const SizedBox(width: 4),
+            Text(
+              ' ${AppLocalizations.of(context)!.accountSaveToAddressBook} ',
+              style: TextStyle(
+                fontFamily: 'Roboto',
+                fontWeight: FontWeight.w400,
+                fontSize: 14,
+                color: isDark ? AppColors.neutral200 : AppColors.neutral800,
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+
   Widget _buildSaveAddressButton(BuildContext context, CheckoutState state) {
     return GestureDetector(
       onTap: state.isLoading ? null : () => _onSaveAddress(context, state),
@@ -1717,7 +1841,13 @@ class _CheckoutPageViewState extends State<_CheckoutPageView> {
       }
     }
 
-    context.read<CheckoutBloc>().add(SaveCheckoutAddressEvent(input: input));
+    context.read<CheckoutBloc>().add(
+      SaveCheckoutAddressEvent(
+        input: input,
+        saveToAddressBook:
+            _shouldOfferSaveToAddressBook(state) && _saveToAddressBook,
+      ),
+    );
   }
 
   // =====================================================================

--- a/lib/features/checkout/presentation/widgets/checkout_address_selection_sheet.dart
+++ b/lib/features/checkout/presentation/widgets/checkout_address_selection_sheet.dart
@@ -1,0 +1,205 @@
+import 'package:flutter/material.dart';
+
+import '../../../../core/theme/app_theme.dart';
+import '../../data/models/checkout_model.dart';
+
+class CheckoutAddressSelectionSheet extends StatelessWidget {
+  final String title;
+  final String addButtonLabel;
+  final List<CheckoutAddress> addresses;
+  final String? selectedAddressId;
+  final ScrollController? scrollController;
+  final ValueChanged<CheckoutAddress> onAddressSelected;
+  final VoidCallback onAddNewAddress;
+  final String Function(CheckoutAddress address) addressTypeLabelBuilder;
+  final String Function(String phone) phoneLabelBuilder;
+
+  const CheckoutAddressSelectionSheet({
+    super.key,
+    required this.title,
+    required this.addButtonLabel,
+    required this.addresses,
+    required this.onAddressSelected,
+    required this.onAddNewAddress,
+    required this.addressTypeLabelBuilder,
+    required this.phoneLabelBuilder,
+    this.selectedAddressId,
+    this.scrollController,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    final isDark = Theme.of(context).brightness == Brightness.dark;
+
+    return Padding(
+      padding: const EdgeInsets.fromLTRB(20, 20, 20, 20),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Center(
+            child: Container(
+              width: 40,
+              height: 4,
+              margin: const EdgeInsets.only(bottom: 16),
+              decoration: BoxDecoration(
+                color: isDark ? AppColors.neutral700 : AppColors.neutral300,
+                borderRadius: BorderRadius.circular(2),
+              ),
+            ),
+          ),
+          Text(
+            title,
+            style: TextStyle(
+              fontFamily: 'Roboto',
+              fontWeight: FontWeight.w600,
+              fontSize: 16,
+              color: isDark ? AppColors.neutral100 : AppColors.neutral900,
+            ),
+          ),
+          const SizedBox(height: 16),
+          Expanded(
+            child: ListView.separated(
+              controller: scrollController,
+              itemCount: addresses.length,
+              separatorBuilder: (context, index) => const SizedBox(height: 8),
+              itemBuilder: (context, index) {
+                final address = addresses[index];
+                final isSelected = selectedAddressId == address.id;
+
+                return GestureDetector(
+                  onTap: () => onAddressSelected(address),
+                  child: Container(
+                    padding: const EdgeInsets.all(12),
+                    decoration: BoxDecoration(
+                      color: isSelected
+                          ? AppColors.primary500.withValues(alpha: 0.05)
+                          : (isDark
+                                ? AppColors.neutral800
+                                : AppColors.neutral100),
+                      border: Border.all(
+                        color: isSelected
+                            ? AppColors.primary500
+                            : (isDark
+                                  ? AppColors.neutral700
+                                  : AppColors.neutral200),
+                        width: isSelected ? 2 : 1,
+                      ),
+                      borderRadius: BorderRadius.circular(10),
+                    ),
+                    child: Column(
+                      crossAxisAlignment: CrossAxisAlignment.start,
+                      children: [
+                        Row(
+                          children: [
+                            Expanded(
+                              child: Text(
+                                address.displayName,
+                                style: TextStyle(
+                                  fontFamily: 'Roboto',
+                                  fontWeight: FontWeight.w700,
+                                  fontSize: 14,
+                                  color: isSelected
+                                      ? AppColors.primary500
+                                      : (isDark
+                                            ? AppColors.neutral100
+                                            : AppColors.neutral900),
+                                ),
+                              ),
+                            ),
+                            _AddressTypeChip(
+                              text: addressTypeLabelBuilder(address),
+                            ),
+                          ],
+                        ),
+                        const SizedBox(height: 4),
+                        Text(
+                          address.fullAddress,
+                          style: TextStyle(
+                            fontFamily: 'Roboto',
+                            fontSize: 13,
+                            color: isDark
+                                ? AppColors.neutral400
+                                : AppColors.neutral800,
+                          ),
+                        ),
+                        if (address.phone != null &&
+                            address.phone!.isNotEmpty) ...[
+                          const SizedBox(height: 2),
+                          Text(
+                            phoneLabelBuilder(address.phone!),
+                            style: TextStyle(
+                              fontFamily: 'Roboto',
+                              fontSize: 12,
+                              color: isDark
+                                  ? AppColors.neutral500
+                                  : AppColors.neutral500,
+                            ),
+                          ),
+                        ],
+                      ],
+                    ),
+                  ),
+                );
+              },
+            ),
+          ),
+          const SizedBox(height: 16),
+          SafeArea(
+            top: false,
+            child: SizedBox(
+              width: double.infinity,
+              child: ElevatedButton(
+                onPressed: onAddNewAddress,
+                style: ElevatedButton.styleFrom(
+                  backgroundColor: AppColors.primary500,
+                  foregroundColor: AppColors.white,
+                  elevation: 0,
+                  padding: const EdgeInsets.symmetric(vertical: 14),
+                  shape: RoundedRectangleBorder(
+                    borderRadius: BorderRadius.circular(54),
+                  ),
+                ),
+                child: Text(
+                  addButtonLabel,
+                  style: const TextStyle(
+                    fontFamily: 'Roboto',
+                    fontWeight: FontWeight.w700,
+                    fontSize: 14,
+                    color: AppColors.white,
+                  ),
+                ),
+              ),
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+class _AddressTypeChip extends StatelessWidget {
+  final String text;
+
+  const _AddressTypeChip({required this.text});
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      padding: const EdgeInsets.symmetric(horizontal: 6, vertical: 4),
+      decoration: BoxDecoration(
+        color: const Color(0xFFDCFCE7),
+        border: Border.all(color: const Color(0xFFB9F8CF)),
+        borderRadius: BorderRadius.circular(6),
+      ),
+      child: Text(
+        text,
+        style: const TextStyle(
+          fontFamily: 'Roboto',
+          fontWeight: FontWeight.w700,
+          fontSize: 12,
+          color: Color(0xFF00A63E),
+        ),
+      ),
+    );
+  }
+}

--- a/test/add_review_page_test.dart
+++ b/test/add_review_page_test.dart
@@ -1,0 +1,88 @@
+import 'package:bagisto_flutter/features/account/data/models/account_models.dart';
+import 'package:bagisto_flutter/features/account/data/repository/account_repository.dart';
+import 'package:bagisto_flutter/features/account/presentation/bloc/add_review_bloc.dart';
+import 'package:bagisto_flutter/features/account/presentation/pages/add_review_page.dart';
+import 'package:bagisto_flutter/l10n/app_localizations.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:graphql_flutter/graphql_flutter.dart';
+
+void main() {
+  testWidgets('required review fields are marked before submission', (
+    WidgetTester tester,
+  ) async {
+    await tester.pumpWidget(_buildTestApp());
+
+    expect(find.text('Rating *', findRichText: true), findsOneWidget);
+    expect(find.text('Nick Name *', findRichText: true), findsOneWidget);
+    expect(find.text('Summary *', findRichText: true), findsOneWidget);
+    expect(find.text('Review *', findRichText: true), findsOneWidget);
+  });
+
+  testWidgets(
+    'submitting an empty review shows inline required errors and does not submit',
+    (WidgetTester tester) async {
+      final repository = _FakeAccountRepository();
+
+      await tester.pumpWidget(_buildTestApp(repository: repository));
+
+      await tester.tap(find.text('Submit Review'));
+      await tester.pump();
+
+      expect(find.text('Please select a rating'), findsOneWidget);
+      expect(find.text('Name is required'), findsOneWidget);
+      expect(find.text('Summary is required'), findsOneWidget);
+      expect(find.text('Review is required'), findsOneWidget);
+      expect(find.byType(SnackBar), findsNothing);
+      expect(repository.createReviewCalls, 0);
+    },
+  );
+}
+
+Widget _buildTestApp({AccountRepository? repository}) {
+  final accountRepository = repository ?? _FakeAccountRepository();
+
+  return MaterialApp(
+    localizationsDelegates: AppLocalizations.localizationsDelegates,
+    supportedLocales: AppLocalizations.supportedLocales,
+    home: BlocProvider(
+      create: (_) => AddReviewBloc(repository: accountRepository),
+      child: const AddReviewPage(
+        productId: 10,
+        productName: 'Arctic Frost Winter Accessories Bundle',
+      ),
+    ),
+  );
+}
+
+class _FakeAccountRepository extends AccountRepository {
+  int createReviewCalls = 0;
+
+  _FakeAccountRepository()
+    : super(
+        client: GraphQLClient(
+          link: HttpLink('https://example.com/graphql'),
+          cache: GraphQLCache(store: InMemoryStore()),
+        ),
+      );
+
+  @override
+  Future<ProductReview> createProductReview({
+    required int productId,
+    required String title,
+    required String comment,
+    required int rating,
+    required String name,
+  }) async {
+    createReviewCalls += 1;
+    return ProductReview(
+      id: '1',
+      name: name,
+      title: title,
+      comment: comment,
+      rating: rating,
+      createdAt: '2026-05-22T10:00:00.000Z',
+    );
+  }
+}

--- a/test/checkout_address_sheet_test.dart
+++ b/test/checkout_address_sheet_test.dart
@@ -1,0 +1,371 @@
+import 'dart:async';
+
+import 'package:bagisto_flutter/features/checkout/data/models/checkout_model.dart';
+import 'package:bagisto_flutter/features/checkout/data/repository/checkout_repository.dart';
+import 'package:bagisto_flutter/features/checkout/presentation/bloc/checkout_bloc.dart';
+import 'package:bagisto_flutter/features/checkout/presentation/helpers/checkout_address_sheet_helpers.dart';
+import 'package:bagisto_flutter/features/checkout/presentation/widgets/checkout_address_selection_sheet.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:graphql_flutter/graphql_flutter.dart';
+
+void main() {
+  test(
+    'findNewlyAddedSelectableAddress resolves the new saved address from customer ids',
+    () {
+      const existingAddress = CheckoutAddress(
+        id: 'cust-1',
+        firstName: 'Paul',
+        lastName: 'Doe',
+      );
+      const anotherAddress = CheckoutAddress(
+        id: 'cust-2',
+        firstName: 'Sujal',
+        lastName: 'Gorivale',
+      );
+      const newAddress = CheckoutAddress(
+        id: 'cust-3',
+        firstName: 'Jitendra',
+        lastName: 'Office',
+      );
+
+      final result = findNewlyAddedSelectableAddress(
+        previousCustomerIds: const {'cust-1', 'cust-2'},
+        refreshedCustomerIds: const ['cust-1', 'cust-2', 'cust-3'],
+        refreshedAddresses: const [existingAddress, anotherAddress, newAddress],
+      );
+
+      expect(result?.id, 'cust-3');
+    },
+  );
+
+  test('findNewlyAddedCheckoutAddress returns the first new address by id', () {
+    const existingAddress = CheckoutAddress(
+      id: 'addr-1',
+      firstName: 'Paul',
+      lastName: 'Doe',
+    );
+    const newAddress = CheckoutAddress(
+      id: 'addr-2',
+      firstName: 'Jitendra',
+      lastName: 'Office',
+    );
+
+    final result = findNewlyAddedCheckoutAddress(
+      previousIds: const {'addr-1'},
+      refreshedAddresses: const [existingAddress, newAddress],
+    );
+
+    expect(result?.id, 'addr-2');
+  });
+
+  test(
+    'RefreshSavedAddresses loads customer fallback addresses when checkout addresses are empty',
+    () async {
+      final repository = _FakeCheckoutRepository(
+        checkoutAddresses: const [],
+        customerAddresses: const [
+          CheckoutAddress(
+            id: 'cust-1',
+            firstName: 'Fallback',
+            lastName: 'Address',
+          ),
+        ],
+      );
+      final bloc = _SeededCheckoutBloc(repository: repository)
+        ..seedState(
+          const CheckoutState(
+            isGuest: false,
+            addresses: [
+              CheckoutAddress(
+                id: 'stale-1',
+                firstName: 'Old',
+                lastName: 'Address',
+              ),
+            ],
+          ),
+        );
+      final completer = Completer<List<CheckoutAddress>>();
+
+      final emission = expectLater(
+        bloc.stream,
+        emits(
+          isA<CheckoutState>().having(
+            (state) => state.addresses.single.id,
+            'refreshed address id',
+            'cust-1',
+          ),
+        ),
+      );
+
+      bloc.add(RefreshSavedAddresses(completer: completer));
+
+      await emission;
+      expect((await completer.future).single.id, 'cust-1');
+      await bloc.close();
+    },
+  );
+
+  test(
+    'SelectSavedAddress includes separate shipping fields when shipping differs from billing',
+    () async {
+      final repository = _FakeCheckoutRepository(
+        checkoutAddresses: const [],
+        customerAddresses: const [],
+        shippingRates: const [],
+      );
+      final bloc = _SeededCheckoutBloc(repository: repository)
+        ..seedState(const CheckoutState(isGuest: false, isVirtualOnly: false));
+
+      const billingAddress = CheckoutAddress(
+        id: 'bill-1',
+        firstName: 'Billing',
+        lastName: 'User',
+        address: 'Billing Street',
+        city: 'Noida',
+        state: 'UP',
+        country: 'IN',
+        postcode: '201001',
+        phone: '1111111111',
+      );
+      const shippingAddress = CheckoutAddress(
+        id: 'ship-1',
+        firstName: 'Shipping',
+        lastName: 'User',
+        address: 'Shipping Street',
+        city: 'Mumbai',
+        state: 'MH',
+        country: 'IN',
+        postcode: '400001',
+        phone: '9999999999',
+      );
+
+      final emission = expectLater(
+        bloc.stream,
+        emitsThrough(
+          isA<CheckoutState>().having(
+            (state) => state.selectedAddress?.id,
+            'selected billing address id',
+            'bill-1',
+          ),
+        ),
+      );
+
+      bloc.add(
+        const SelectSavedAddress(
+          address: billingAddress,
+          useForShipping: false,
+          shippingAddress: shippingAddress,
+        ),
+      );
+
+      await emission;
+      expect(repository.lastSavedInput?['useForShipping'], isFalse);
+      expect(repository.lastSavedInput?['shippingFirstName'], 'Shipping');
+      expect(repository.lastSavedInput?['shippingCity'], 'Mumbai');
+      await bloc.close();
+    },
+  );
+
+  test(
+    'SaveCheckoutAddressEvent saves first manual checkout address to the address book when requested',
+    () async {
+      final repository = _FakeCheckoutRepository(
+        checkoutAddresses: const [],
+        customerAddresses: const [],
+        shippingRates: const [],
+      );
+      final bloc = _SeededCheckoutBloc(repository: repository)
+        ..seedState(const CheckoutState(isGuest: false, isVirtualOnly: false));
+
+      final emission = expectLater(
+        bloc.stream,
+        emitsThrough(
+          isA<CheckoutState>()
+              .having(
+                (state) => state.addressConfirmed,
+                'address confirmed',
+                isTrue,
+              )
+              .having(
+                (state) => state.addresses.single.id,
+                'saved address id',
+                'cust-1',
+              ),
+        ),
+      );
+
+      bloc.add(
+        const SaveCheckoutAddressEvent(
+          input: {
+            'billingFirstName': 'First',
+            'billingLastName': 'Customer',
+            'billingEmail': 'first@example.com',
+            'billingAddress': 'Street 1',
+            'billingCity': 'Noida',
+            'billingCountry': 'IN',
+            'billingState': 'UP',
+            'billingPostcode': '201301',
+            'billingPhoneNumber': '9999999999',
+            'useForShipping': true,
+          },
+          saveToAddressBook: true,
+        ),
+      );
+
+      await emission;
+      expect(repository.lastCreatedCustomerAddressInput?['firstName'], 'First');
+      expect(
+        repository.lastCreatedCustomerAddressInput?['defaultAddress'],
+        isTrue,
+      );
+      expect(
+        repository.lastCreatedCustomerAddressInput?['useForShipping'],
+        isTrue,
+      );
+      await bloc.close();
+    },
+  );
+
+  testWidgets(
+    'CheckoutAddressSelectionSheet shows Add New Address and calls callbacks',
+    (WidgetTester tester) async {
+      CheckoutAddress? tappedAddress;
+      var addTapped = false;
+
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Scaffold(
+            body: CheckoutAddressSelectionSheet(
+              title: 'Select Shipping Address',
+              addButtonLabel: 'Add New Address',
+              addresses: const [
+                CheckoutAddress(
+                  id: 'addr-1',
+                  firstName: 'Paul',
+                  lastName: 'Doe',
+                  address: 'New Noida',
+                  city: 'Noida',
+                  state: 'UP',
+                  country: 'IN',
+                  postcode: '201306',
+                  phone: '5467756767',
+                ),
+              ],
+              selectedAddressId: 'addr-1',
+              onAddressSelected: (address) => tappedAddress = address,
+              onAddNewAddress: () => addTapped = true,
+              addressTypeLabelBuilder: (_) => 'Home',
+              phoneLabelBuilder: (phone) => 'Phone: $phone',
+            ),
+          ),
+        ),
+      );
+
+      expect(find.text('Add New Address'), findsOneWidget);
+
+      await tester.tap(find.text('Paul Doe'));
+      await tester.pump();
+
+      await tester.tap(find.text('Add New Address'));
+      await tester.pump();
+
+      expect(tappedAddress?.id, 'addr-1');
+      expect(addTapped, isTrue);
+    },
+  );
+}
+
+class _SeededCheckoutBloc extends CheckoutBloc {
+  _SeededCheckoutBloc({required super.repository});
+
+  void seedState(CheckoutState state) {
+    emit(state);
+  }
+}
+
+class _FakeCheckoutRepository extends CheckoutRepository {
+  final List<CheckoutAddress> checkoutAddresses;
+  final List<CheckoutAddress> _initialCustomerAddresses;
+  final List<ShippingRate> shippingRates;
+  Map<String, dynamic>? lastSavedInput;
+  Map<String, dynamic>? lastCreatedCustomerAddressInput;
+  late final List<CheckoutAddress> _customerAddresses;
+
+  _FakeCheckoutRepository({
+    required this.checkoutAddresses,
+    required List<CheckoutAddress> customerAddresses,
+    this.shippingRates = const [],
+  }) : _initialCustomerAddresses = customerAddresses,
+       super(
+         client: GraphQLClient(
+           link: HttpLink('https://example.com/graphql'),
+           cache: GraphQLCache(store: InMemoryStore()),
+         ),
+       ) {
+    _customerAddresses = List<CheckoutAddress>.from(_initialCustomerAddresses);
+  }
+
+  List<CheckoutAddress> get customerAddresses => _customerAddresses;
+
+  @override
+  Future<List<CheckoutAddress>> getCheckoutAddresses() async =>
+      checkoutAddresses;
+
+  @override
+  Future<List<CheckoutAddress>> getCustomerAddresses() async =>
+      customerAddresses;
+
+  @override
+  Future<CheckoutAddressResponse> saveCheckoutAddress(
+    Map<String, dynamic> input,
+  ) async {
+    lastSavedInput = Map<String, dynamic>.from(input);
+    return const CheckoutAddressResponse(
+      success: true,
+      cartToken: 'cart-token-1',
+    );
+  }
+
+  @override
+  Future<List<ShippingRate>> getShippingRates({String? queryToken}) async =>
+      shippingRates;
+
+  @override
+  Future<void> saveCustomerAddressFromCheckout(
+    Map<String, dynamic> checkoutInput, {
+    bool defaultAddress = false,
+  }) async {
+    lastCreatedCustomerAddressInput = {
+      'firstName': checkoutInput['billingFirstName'],
+      'lastName': checkoutInput['billingLastName'],
+      'email': checkoutInput['billingEmail'],
+      'address': checkoutInput['billingAddress'],
+      'city': checkoutInput['billingCity'],
+      'state': checkoutInput['billingState'],
+      'country': checkoutInput['billingCountry'],
+      'postcode': checkoutInput['billingPostcode'],
+      'phone': checkoutInput['billingPhoneNumber'],
+      'defaultAddress': defaultAddress,
+      'useForShipping': checkoutInput['useForShipping'] == true,
+    };
+
+    _customerAddresses.add(
+      CheckoutAddress(
+        id: 'cust-${_customerAddresses.length + 1}',
+        addressType: 'home',
+        firstName: checkoutInput['billingFirstName']?.toString() ?? '',
+        lastName: checkoutInput['billingLastName']?.toString() ?? '',
+        address: checkoutInput['billingAddress']?.toString() ?? '',
+        city: checkoutInput['billingCity']?.toString() ?? '',
+        state: checkoutInput['billingState']?.toString(),
+        country: checkoutInput['billingCountry']?.toString(),
+        postcode: checkoutInput['billingPostcode']?.toString(),
+        email: checkoutInput['billingEmail']?.toString(),
+        phone: checkoutInput['billingPhoneNumber']?.toString(),
+        defaultAddress: defaultAddress,
+        useForShipping: checkoutInput['useForShipping'] == true,
+      ),
+    );
+  }
+}

--- a/test/orders_bloc_test.dart
+++ b/test/orders_bloc_test.dart
@@ -1,0 +1,113 @@
+import 'package:bagisto_flutter/features/account/data/models/account_models.dart';
+import 'package:bagisto_flutter/features/account/data/repository/account_repository.dart';
+import 'package:bagisto_flutter/features/account/presentation/bloc/orders_bloc.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:graphql_flutter/graphql_flutter.dart';
+
+void main() {
+  test(
+    'LoadMoreOrders uses the current end cursor and appends the next page',
+    () async {
+      const firstOrder = CustomerOrder(
+        numericId: 1,
+        incrementId: '1001',
+        status: 'pending',
+        grandTotal: 100,
+      );
+      const secondOrder = CustomerOrder(
+        numericId: 2,
+        incrementId: '1002',
+        status: 'processing',
+        grandTotal: 200,
+      );
+
+      final repository = _FakeAccountRepository(
+        responsesByCursor: const {
+          'cursor-1': (
+            orders: [secondOrder],
+            totalCount: 42,
+            hasNextPage: false,
+            endCursor: 'cursor-2',
+          ),
+        },
+      );
+      final bloc = _SeededOrdersBloc(repository: repository)
+        ..seedState(
+          const OrdersState(
+            status: OrdersStatus.loaded,
+            orders: [firstOrder],
+            totalCount: 42,
+            hasNextPage: true,
+            endCursor: 'cursor-1',
+          ),
+        );
+
+      bloc.add(const LoadMoreOrders());
+
+      final finalState = await bloc.stream.firstWhere(
+        (state) => !state.isLoadingMore,
+      );
+
+      expect(finalState.orders.map((order) => order.incrementId).toList(), [
+        '1001',
+        '1002',
+      ]);
+      expect(finalState.endCursor, 'cursor-2');
+      expect(repository.afterCalls, ['cursor-1']);
+      await bloc.close();
+    },
+  );
+}
+
+class _SeededOrdersBloc extends OrdersBloc {
+  _SeededOrdersBloc({required super.repository});
+
+  void seedState(OrdersState state) {
+    emit(state);
+  }
+}
+
+class _FakeAccountRepository extends AccountRepository {
+  final Map<
+    String?,
+    ({
+      List<CustomerOrder> orders,
+      int totalCount,
+      bool hasNextPage,
+      String? endCursor,
+    })
+  >
+  responsesByCursor;
+  final List<String?> afterCalls = [];
+
+  _FakeAccountRepository({required this.responsesByCursor})
+    : super(
+        client: GraphQLClient(
+          link: HttpLink('https://example.com/graphql'),
+          cache: GraphQLCache(store: InMemoryStore()),
+        ),
+      );
+
+  @override
+  Future<
+    ({
+      List<CustomerOrder> orders,
+      int totalCount,
+      bool hasNextPage,
+      String? endCursor,
+    })
+  >
+  getCustomerOrders({int first = 20, String? after, String? status}) async {
+    afterCalls.add(after);
+    final response = responsesByCursor[after];
+    if (response == null) {
+      return (
+        orders: const <CustomerOrder>[],
+        totalCount: 0,
+        hasNextPage: false,
+        endCursor: null,
+      );
+    }
+    return response;
+  }
+}


### PR DESCRIPTION
Checkout address popup fix
You can now select billing/shipping address properly from the checkout sheet, and also add a new address directly from checkout.

Save to address book fix
If a logged-in user has no saved address and enters one manually in checkout, it can now be saved into their address book.

Order pagination fix
Order list “load more” now keeps the correct cursor, so next-page loading works properly.

