### PR TITLE
fix: import address and checkout fixes for v2.4.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,16 @@
 #### This changelog consists the bug & security fixes and new features being included in the releases listed below
 
+# CHANGELOG for v2.4.5
+
+## **v2.4.5 (26th of May, 2026)** - *Release*
+
+* [Improvement] Improved account address state handling for countries without predefined states and preserved saved state values while editing addresses.
+* [Improvement] Simplified account address management with a single "Set as Default" flow and improved dashboard/address book refresh after add or edit actions.
+* [Improvement] Improved checkout saved-address synchronization, including refreshed address selection flows, separate billing and shipping selection handling, and interaction blocking while placing orders.
+* [Fixed] Fixed account default address updates by sending the full payload expected by the API.
+* [Fixed] Fixed checkout address book saving so separate billing and shipping addresses are preserved when they are different.
+* [Fixed] Fixed checkout address selection UI by removing address type badges and preserving separate shipping selections after manual address entry.
+
 # CHANGELOG for v2.4.4
 
 ## **v2.4.4 (22nd of May, 2026)** - *Release*

--- a/lib/features/account/data/repository/account_repository.dart
+++ b/lib/features/account/data/repository/account_repository.dart
@@ -10,6 +10,60 @@ void _logAccountApiMessage(String message) {
   print(message);
 }
 
+Map<String, dynamic> buildCustomerAddressMutationInput({
+  int? addressId,
+  required String firstName,
+  required String lastName,
+  required String address,
+  required String city,
+  required String state,
+  required String country,
+  required String postcode,
+  required String phone,
+  String? email,
+  bool defaultAddress = false,
+}) {
+  final input = <String, dynamic>{
+    'firstName': firstName,
+    'lastName': lastName,
+    'address1': address,
+    'city': city,
+    'state': state,
+    'country': country,
+    'postcode': postcode,
+    'phone': phone,
+    'defaultAddress': defaultAddress,
+  };
+
+  if (addressId != null) {
+    input['addressId'] = addressId;
+  }
+
+  if (email != null && email.isNotEmpty) {
+    input['email'] = email;
+  }
+
+  return input;
+}
+
+Map<String, dynamic> buildSetDefaultCustomerAddressMutationInput({
+  required CustomerAddress address,
+}) {
+  return buildCustomerAddressMutationInput(
+    addressId: address.numericId,
+    firstName: address.firstName,
+    lastName: address.lastName,
+    address: address.address,
+    city: address.city,
+    state: address.state,
+    country: address.country,
+    postcode: address.zipCode,
+    phone: address.phone ?? '',
+    email: address.email,
+    defaultAddress: true,
+  );
+}
+
 /// Repository for Account Dashboard API calls via GraphQL.
 /// Uses authenticated GraphQL client to fetch:
 ///   - Customer Profile  (readCustomerProfile)
@@ -415,35 +469,31 @@ class AccountRepository {
   /// Requires the full address data to be passed.
   Future<CustomerAddress> setDefaultAddress({
     required int addressId,
-    // required String firstName,
-    // required String lastName,
-    // required String address,
-    // required String city,
-    // required String state,
-    // required String country,
-    // required String postcode,
-    // required String phone,
-    // String? email,
-    bool useForShipping = true,
+    required String firstName,
+    required String lastName,
+    required String address,
+    required String city,
+    required String state,
+    required String country,
+    required String postcode,
+    required String phone,
+    String? email,
   }) async {
     debugPrint('📍 AccountRepo.setDefaultAddress (addressId=$addressId)');
 
-    final input = <String, dynamic>{
-      'addressId': addressId,
-      // 'firstName': firstName,
-      // 'lastName': lastName,
-      // 'address1': address,
-      // 'city': city,
-      // 'state': state,
-      // 'country': country,
-      // 'postcode': postcode,
-      // 'phone': phone,
-      'defaultAddress': true,
-      'useForShipping': useForShipping,
-    };
-    // if (email != null && email.isNotEmpty) {
-    //   input['email'] = email;
-    // }
+    final input = buildCustomerAddressMutationInput(
+      addressId: addressId,
+      firstName: firstName,
+      lastName: lastName,
+      address: address,
+      city: city,
+      state: state,
+      country: country,
+      postcode: postcode,
+      phone: phone,
+      email: email,
+      defaultAddress: true,
+    );
 
     final result = await client.mutate(
       MutationOptions(
@@ -494,7 +544,7 @@ class AccountRepository {
   /// Add a new customer address via createAddUpdateCustomerAddress mutation.
   /// Schema introspection: createAddUpdateCustomerAddressInput fields:
   ///   firstName, lastName, email, phone, address1, address2,
-  ///   country, state, city, postcode, defaultAddress, useForShipping
+  ///   country, state, city, postcode, defaultAddress
   Future<CustomerAddress> createAddress({
     required String firstName,
     required String lastName,
@@ -508,25 +558,21 @@ class AccountRepository {
     String? companyName,
     String? vatId,
     bool defaultAddress = false,
-    bool useForShipping = false,
   }) async {
     debugPrint('📍 AccountRepo.createAddress');
 
-    final input = <String, dynamic>{
-      'firstName': firstName,
-      'lastName': lastName,
-      'address1': address,
-      'city': city,
-      'state': state,
-      'country': country,
-      'postcode': postcode,
-      'phone': phone,
-      'defaultAddress': defaultAddress,
-      'useForShipping': useForShipping,
-    };
-    if (email != null && email.isNotEmpty) {
-      input['email'] = email;
-    }
+    final input = buildCustomerAddressMutationInput(
+      firstName: firstName,
+      lastName: lastName,
+      address: address,
+      city: city,
+      state: state,
+      country: country,
+      postcode: postcode,
+      phone: phone,
+      email: email,
+      defaultAddress: defaultAddress,
+    );
     // Note: companyName and vatId are NOT supported by
     // createAddUpdateCustomerAddressInput on this server.
 
@@ -570,26 +616,22 @@ class AccountRepository {
     String? companyName,
     String? vatId,
     bool defaultAddress = false,
-    bool useForShipping = false,
   }) async {
     debugPrint('📍 AccountRepo.updateAddress (addressId=$addressId)');
 
-    final input = <String, dynamic>{
-      'addressId': addressId,
-      'firstName': firstName,
-      'lastName': lastName,
-      'address1': address,
-      'city': city,
-      'state': state,
-      'country': country,
-      'postcode': postcode,
-      'phone': phone,
-      'defaultAddress': defaultAddress,
-      'useForShipping': useForShipping,
-    };
-    if (email != null && email.isNotEmpty) {
-      input['email'] = email;
-    }
+    final input = buildCustomerAddressMutationInput(
+      addressId: addressId,
+      firstName: firstName,
+      lastName: lastName,
+      address: address,
+      city: city,
+      state: state,
+      country: country,
+      postcode: postcode,
+      phone: phone,
+      email: email,
+      defaultAddress: defaultAddress,
+    );
 
     final result = await client.mutate(
       MutationOptions(

--- a/lib/features/account/presentation/bloc/address_book_bloc.dart
+++ b/lib/features/account/presentation/bloc/address_book_bloc.dart
@@ -102,7 +102,6 @@ class CreateAddress extends AddressBookEvent {
   final String? companyName;
   final String? vatId;
   final bool defaultAddress;
-  final bool useForShipping;
 
   const CreateAddress({
     required this.firstName,
@@ -117,7 +116,6 @@ class CreateAddress extends AddressBookEvent {
     this.companyName,
     this.vatId,
     this.defaultAddress = false,
-    this.useForShipping = false,
   });
 
   @override
@@ -134,7 +132,6 @@ class CreateAddress extends AddressBookEvent {
     companyName,
     vatId,
     defaultAddress,
-    useForShipping,
   ];
 }
 
@@ -153,7 +150,6 @@ class UpdateAddress extends AddressBookEvent {
   final String? companyName;
   final String? vatId;
   final bool defaultAddress;
-  final bool useForShipping;
 
   const UpdateAddress({
     required this.addressId,
@@ -169,7 +165,6 @@ class UpdateAddress extends AddressBookEvent {
     this.companyName,
     this.vatId,
     this.defaultAddress = false,
-    this.useForShipping = false,
   });
 
   @override
@@ -187,7 +182,6 @@ class UpdateAddress extends AddressBookEvent {
     companyName,
     vatId,
     defaultAddress,
-    useForShipping,
   ];
 }
 
@@ -315,28 +309,26 @@ class AddressBookBloc extends Bloc<AddressBookEvent, AddressBookState> {
     emit(state.copyWith(isPerformingAction: true, actionMessage: null));
 
     try {
-      // Find the address in state if fields are null
-      state.addresses.firstWhere(
-        (a) => a.numericId == event.addressId,
-        orElse: () => throw Exception('Selected address not found in state'),
-      );
-
       await repository.setDefaultAddress(
         addressId: event.addressId,
-        useForShipping: event.useForShipping,
+        firstName: event.firstName ?? '',
+        lastName: event.lastName ?? '',
+        address: event.address ?? '',
+        city: event.city ?? '',
+        state: event.state ?? '',
+        country: event.country ?? '',
+        postcode: event.postcode ?? '',
+        phone: event.phone ?? '',
+        email: event.email,
       );
 
-      // Optimistic update using model's copyWith — future-proof
-      final updatedAddresses = state.addresses
-          .map(
-            (addr) =>
-                addr.copyWith(isDefault: addr.numericId == event.addressId),
-          )
-          .toList();
+      final refreshedAddresses = await repository.getCustomerAddresses(
+        first: 100,
+      );
 
       emit(
         state.copyWith(
-          addresses: updatedAddresses,
+          addresses: refreshedAddresses,
           isPerformingAction: false,
           actionMessage: 'Address set as default',
         ),
@@ -420,7 +412,6 @@ class AddressBookBloc extends Bloc<AddressBookEvent, AddressBookState> {
         companyName: event.companyName,
         vatId: event.vatId,
         defaultAddress: event.defaultAddress,
-        useForShipping: event.useForShipping,
       );
 
       final updatedAddresses = [...state.addresses, newAddress];
@@ -473,7 +464,6 @@ class AddressBookBloc extends Bloc<AddressBookEvent, AddressBookState> {
         companyName: event.companyName,
         vatId: event.vatId,
         defaultAddress: event.defaultAddress,
-        useForShipping: event.useForShipping,
       );
 
       // Replace the old address in the local list

--- a/lib/features/account/presentation/helpers/account_dashboard_helpers.dart
+++ b/lib/features/account/presentation/helpers/account_dashboard_helpers.dart
@@ -1,0 +1,23 @@
+import '../../data/models/account_models.dart';
+
+CustomerAddress? resolveDashboardDefaultAddress(
+  List<CustomerAddress> addresses,
+) {
+  if (addresses.isEmpty) return null;
+
+  for (final address in addresses) {
+    if (address.isDefault) {
+      return address;
+    }
+  }
+
+  return addresses.first;
+}
+
+Future<void> refreshAccountDashboardAfterAddressBook<T>({
+  required Future<T> Function() openAddressBook,
+  required void Function() onReturn,
+}) async {
+  await openAddressBook();
+  onReturn();
+}

--- a/lib/features/account/presentation/helpers/address_book_navigation_helpers.dart
+++ b/lib/features/account/presentation/helpers/address_book_navigation_helpers.dart
@@ -1,0 +1,9 @@
+Future<void> refreshAddressBookAfterForm({
+  required Future<bool?> Function() openForm,
+  required void Function() onSaved,
+}) async {
+  final didSave = await openForm();
+  if (didSave == true) {
+    onSaved();
+  }
+}

--- a/lib/features/account/presentation/pages/account_dashboard_page.dart
+++ b/lib/features/account/presentation/pages/account_dashboard_page.dart
@@ -14,6 +14,7 @@ import '../widgets/recent_orders_section.dart';
 import '../widgets/wishlist_section.dart';
 import '../widgets/default_addresses_section.dart';
 import '../widgets/product_reviews_section.dart';
+import '../helpers/account_dashboard_helpers.dart';
 import 'account_menu_page.dart';
 import 'address_book_page.dart';
 import 'reviews_page.dart';
@@ -25,7 +26,7 @@ import 'reviews_page.dart';
 ///   - Quick action chips (My Orders, Account, Settings)
 ///   - Recent Orders (horizontal scroll)
 ///   - Wishlist Items (horizontal scroll)
-///   - Default Addresses (billing & shipping)
+///   - Default address
 ///   - Product Reviews
 class AccountDashboardPage extends StatefulWidget {
   const AccountDashboardPage({super.key});
@@ -154,18 +155,28 @@ class _AccountDashboardPageState extends State<AccountDashboardPage>
                     addresses: state.addresses,
                     onViewAll: () {
                       final repository = context.read<AccountRepository>();
-                      Navigator.of(context).push(
-                        MaterialPageRoute(
-                          builder: (_) => RepositoryProvider.value(
-                            value: repository,
-                            child: BlocProvider(
-                              create: (_) => AddressBookBloc(
-                                repository: repository,
-                              )..add(const LoadAddresses()),
-                              child: const AddressBookPage(),
+                      refreshAccountDashboardAfterAddressBook(
+                        openAddressBook: () {
+                          return Navigator.of(context).push(
+                            MaterialPageRoute(
+                              builder: (_) => RepositoryProvider.value(
+                                value: repository,
+                                child: BlocProvider(
+                                  create: (_) =>
+                                      AddressBookBloc(repository: repository)
+                                        ..add(const LoadAddresses()),
+                                  child: const AddressBookPage(),
+                                ),
+                              ),
                             ),
-                          ),
-                        ),
+                          );
+                        },
+                        onReturn: () {
+                          if (!context.mounted) return;
+                          context.read<AccountDashboardBloc>().add(
+                            const RefreshAccountDashboard(),
+                          );
+                        },
                       );
                     },
                   ),
@@ -183,9 +194,9 @@ class _AccountDashboardPageState extends State<AccountDashboardPage>
                           builder: (_) => RepositoryProvider.value(
                             value: repository,
                             child: BlocProvider(
-                              create: (_) => ReviewBloc(
-                                repository: repository,
-                              )..add(const LoadReviews()),
+                              create: (_) =>
+                                  ReviewBloc(repository: repository)
+                                    ..add(const LoadReviews()),
                               child: const ReviewsPage(),
                             ),
                           ),

--- a/lib/features/account/presentation/pages/account_menu_page.dart
+++ b/lib/features/account/presentation/pages/account_menu_page.dart
@@ -14,6 +14,7 @@ import '../bloc/edit_account_bloc.dart';
 import '../bloc/orders_bloc.dart';
 import '../bloc/review_bloc.dart';
 import '../bloc/wishlist_bloc.dart';
+import '../helpers/account_dashboard_helpers.dart';
 import '../pages/address_book_page.dart';
 import '../pages/compare_products_page.dart';
 import '../pages/downloadable_products_page.dart';
@@ -307,7 +308,10 @@ class _AccountMenuBody extends StatelessWidget {
             onTap: () => _onMenuItemTap(context, AccountMenuAction.preferences),
           ),
           const SizedBox(height: 2),
-          AccountMenuItem(label: l10n.accountLogout, onTap: () => _onLogout(context)),
+          AccountMenuItem(
+            label: l10n.accountLogout,
+            onTap: () => _onLogout(context),
+          ),
         ],
       ),
     );
@@ -399,18 +403,32 @@ class _AccountMenuBody extends StatelessWidget {
         break;
       case AccountMenuAction.addressBook:
         final repository = context.read<AccountRepository>();
-        Navigator.of(context).push(
-          MaterialPageRoute(
-            builder: (_) => RepositoryProvider.value(
-              value: repository,
-              child: BlocProvider(
-                create: (_) =>
-                    AddressBookBloc(repository: repository)
-                      ..add(const LoadAddresses()),
-                child: const AddressBookPage(),
+        refreshAccountDashboardAfterAddressBook(
+          openAddressBook: () {
+            return Navigator.of(context).push(
+              MaterialPageRoute(
+                builder: (_) => RepositoryProvider.value(
+                  value: repository,
+                  child: BlocProvider(
+                    create: (_) =>
+                        AddressBookBloc(repository: repository)
+                          ..add(const LoadAddresses()),
+                    child: const AddressBookPage(),
+                  ),
+                ),
               ),
-            ),
-          ),
+            );
+          },
+          onReturn: () {
+            if (!context.mounted) return;
+            try {
+              context.read<AccountDashboardBloc>().add(
+                const RefreshAccountDashboard(),
+              );
+            } catch (_) {
+              // AccountDashboardBloc not in tree — skip
+            }
+          },
         );
         break;
       case AccountMenuAction.editAccount:

--- a/lib/features/account/presentation/pages/add_address_page.dart
+++ b/lib/features/account/presentation/pages/add_address_page.dart
@@ -1,3 +1,5 @@
+import 'dart:convert';
+
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 import '../../../../core/error/error_mapper.dart';
@@ -7,6 +9,8 @@ import '../../../../l10n/app_localizations.dart';
 import '../../data/models/account_models.dart';
 import '../../data/repository/account_repository.dart';
 import '../bloc/address_book_bloc.dart';
+import '../utils/address_debug_payload.dart';
+import '../utils/address_state_field_behavior.dart';
 import '../widgets/address_form_field.dart';
 
 /// Add / Edit Address Page — Figma node-id=204-6116
@@ -17,7 +21,7 @@ import '../widgets/address_form_field.dart';
 ///     First Name*, Last Name*, Email, Company Name, VAT id,
 ///     Street Address*, Country* (dropdown), State* (dropdown),
 ///     City*, Zip/Postcode*, TelePhone*
-///   - Toggle switches: Default billing / Default shipping address
+///   - Toggle switch: Set as Default
 ///   - Bottom sticky "Save to Address Book" / "Update Address" button
 ///
 /// Pass [editingAddress] to pre-populate the form for editing.
@@ -65,7 +69,6 @@ class _AddAddressPageState extends State<AddAddressPage> {
 
   // Switch states
   bool _isDefaultBilling = false;
-  bool _isDefaultShipping = false;
 
   // Country / State data
   List<Country> _countries = [];
@@ -77,6 +80,10 @@ class _AddAddressPageState extends State<AddAddressPage> {
 
   // Submission state
   bool _isSubmitting = false;
+
+  bool get _useStateDropdown => shouldUseStateDropdown(
+    availableStateNames: _states.map((state) => state.name).toList(),
+  );
 
   @override
   void initState() {
@@ -94,6 +101,11 @@ class _AddAddressPageState extends State<AddAddressPage> {
     final addr = widget.editingAddress;
     if (addr == null) return;
 
+    debugPrint(
+      '📝 Edit Address loaded for addressId=${addr.numericId}: '
+      '${jsonEncode(buildEditAddressDebugPayload(addr))}',
+    );
+
     _firstNameCtrl.text = addr.firstName;
     _lastNameCtrl.text = addr.lastName;
     _emailCtrl.text = addr.email ?? '';
@@ -104,7 +116,6 @@ class _AddAddressPageState extends State<AddAddressPage> {
     _postcodeCtrl.text = addr.zipCode;
     _phoneCtrl.text = addr.phone ?? '';
     _isDefaultBilling = addr.isDefault;
-    _isDefaultShipping = addr.useForShipping;
 
     // Country & State will be matched after countries load
     // Store raw values so _loadCountries can match them
@@ -175,20 +186,9 @@ class _AddAddressPageState extends State<AddAddressPage> {
             _selectedCountry = match;
             _countryDisplayCtrl.text = match.name;
           });
-          // Load states for this country, then match saved state
-          await _loadStates(match);
-          if (mounted && _states.isNotEmpty) {
-            final stateMatch = _states.cast<CountryState?>().firstWhere(
-              (s) => s!.code == addr.state || s.name == addr.state,
-              orElse: () => null,
-            );
-            if (stateMatch != null) {
-              setState(() {
-                _selectedState = stateMatch;
-                _stateDisplayCtrl.text = stateMatch.name;
-              });
-            }
-          }
+          // Load states for this country, then restore the saved state value
+          // when the country has no predefined state list.
+          await _loadStates(match, savedStateText: addr.state);
         }
       }
     } catch (e) {
@@ -212,22 +212,42 @@ class _AddAddressPageState extends State<AddAddressPage> {
     }
   }
 
-  Future<void> _loadStates(Country country) async {
+  Future<void> _loadStates(Country country, {String? savedStateText}) async {
+    final normalizedSavedState = savedStateText?.trim() ?? '';
+
     if (!mounted) return;
     setState(() {
       _loadingStates = true;
       _states = [];
       _selectedState = null;
-      _stateDisplayCtrl.clear();
+      if (normalizedSavedState.isEmpty) {
+        _stateDisplayCtrl.clear();
+      }
     });
 
     try {
       final repo = context.read<AccountRepository>();
       final states = await repo.getCountryStates(countryId: country.numericId);
       if (!mounted) return;
+
+      final stateMatch = normalizedSavedState.isEmpty
+          ? null
+          : states.cast<CountryState?>().firstWhere(
+              (state) =>
+                  state!.code == normalizedSavedState ||
+                  state.name == normalizedSavedState,
+              orElse: () => null,
+            );
+      final resolvedStateText = resolveStateFieldText(
+        savedStateText: normalizedSavedState,
+        matchedStateName: stateMatch?.name,
+      );
+
       setState(() {
         _states = states;
         _loadingStates = false;
+        _selectedState = stateMatch;
+        _stateDisplayCtrl.text = resolvedStateText;
       });
 
       // Show warning if no states available for this country
@@ -292,15 +312,9 @@ class _AddAddressPageState extends State<AddAddressPage> {
     final l10n = AppLocalizations.of(context)!;
 
     if (_loadingStates) return;
+    if (_states.isEmpty) return;
 
     final isDark = Theme.of(context).brightness == Brightness.dark;
-
-    // If no states — allow free text entry
-    if (_states.isEmpty) {
-      _showFreeTextStateInput(isDark);
-      return;
-    }
-
     final selected = await SelectionSheet.show<CountryState>(
       context: context,
       title: l10n.checkoutSelectState,
@@ -321,22 +335,6 @@ class _AddAddressPageState extends State<AddAddressPage> {
     setState(() {
       _selectedState = selected;
       _stateDisplayCtrl.text = selected.name;
-    });
-  }
-
-  Future<void> _showFreeTextStateInput(bool isDark) async {
-    final value = await showFreeTextStateDialog(
-      context: context,
-      currentValue: _stateDisplayCtrl.text,
-      isDark: isDark,
-    );
-
-    if (!mounted) return;
-    if (value == null || value.isEmpty) return;
-
-    setState(() {
-      _selectedState = null;
-      _stateDisplayCtrl.text = value;
     });
   }
 
@@ -387,7 +385,6 @@ class _AddAddressPageState extends State<AddAddressPage> {
               postcode: _postcodeCtrl.text.trim(),
               phone: _phoneCtrl.text.trim(),
               defaultAddress: _isDefaultBilling,
-              useForShipping: _isDefaultShipping,
             )
           : CreateAddress(
               firstName: _firstNameCtrl.text.trim(),
@@ -402,7 +399,6 @@ class _AddAddressPageState extends State<AddAddressPage> {
               postcode: _postcodeCtrl.text.trim(),
               phone: _phoneCtrl.text.trim(),
               defaultAddress: _isDefaultBilling,
-              useForShipping: _isDefaultShipping,
             ),
     );
   }
@@ -515,7 +511,9 @@ class _AddAddressPageState extends State<AddAddressPage> {
             child: Padding(
               padding: const EdgeInsets.symmetric(horizontal: 12),
               child: Text(
-                _isEditing ? l10n.accountEditAddress : l10n.accountAddNewAddress,
+                _isEditing
+                    ? l10n.accountEditAddress
+                    : l10n.accountAddNewAddress,
                 style: TextStyle(
                   fontFamily: 'Roboto',
                   fontWeight: FontWeight.w600,
@@ -688,8 +686,10 @@ class _AddAddressPageState extends State<AddAddressPage> {
                     controller: _stateDisplayCtrl,
                     label: l10n.checkoutState,
                     isRequired: true,
-                    isDropdown: true,
-                    onDropdownTap: _loadingStates ? null : _onStateTap,
+                    isDropdown: _useStateDropdown,
+                    onDropdownTap: _useStateDropdown && !_loadingStates
+                        ? _onStateTap
+                        : null,
                     enabled: _selectedCountry != null && !_loadingStates,
                     validator: (v) {
                       if (v == null || v.trim().isEmpty) {
@@ -773,22 +773,12 @@ class _AddAddressPageState extends State<AddAddressPage> {
 
             const SizedBox(height: 8),
 
-            // ── Change default billing address switch ──
+            // ── Set as Default switch ──
             _buildSwitch(
               isDark: isDark,
-              label: l10n.accountChangeDefaultBillingAddress,
+              label: l10n.accountSetAsDefault,
               value: _isDefaultBilling,
               onChanged: (v) => setState(() => _isDefaultBilling = v),
-            ),
-
-            const SizedBox(height: 8),
-
-            // ── Change default shipping address switch ──
-            _buildSwitch(
-              isDark: isDark,
-              label: l10n.accountChangeDefaultShippingAddress,
-              value: _isDefaultShipping,
-              onChanged: (v) => setState(() => _isDefaultShipping = v),
             ),
 
             // Extra space for bottom button
@@ -899,7 +889,11 @@ class _AddAddressPageState extends State<AddAddressPage> {
                     color: AppColors.white,
                   ),
                 )
-              : Text(_isEditing ? l10n.accountUpdateAddress : l10n.accountSaveToAddressBook),
+              : Text(
+                  _isEditing
+                      ? l10n.accountUpdateAddress
+                      : l10n.accountSaveToAddressBook,
+                ),
         ),
       ),
     );

--- a/lib/features/account/presentation/pages/address_book_page.dart
+++ b/lib/features/account/presentation/pages/address_book_page.dart
@@ -6,6 +6,7 @@ import '../../../../core/theme/app_theme.dart';
 import '../../../../l10n/app_localizations.dart';
 import '../../data/repository/account_repository.dart';
 import '../bloc/address_book_bloc.dart';
+import '../helpers/address_book_navigation_helpers.dart';
 import '../widgets/address_card.dart';
 import 'add_address_page.dart';
 
@@ -189,17 +190,22 @@ class AddressBookPage extends StatelessWidget {
               // Disable button while a mutation is in progress
               onPressed: isPerforming
                   ? null
-                  : () {
-                      Navigator.of(selectorContext).push<bool>(
-                        MaterialPageRoute(
-                          builder: (_) => RepositoryProvider.value(
-                            value: repository,
-                            child: BlocProvider.value(
-                              value: bloc,
-                              child: const AddAddressPage(),
+                  : () async {
+                      await refreshAddressBookAfterForm(
+                        openForm: () {
+                          return Navigator.of(selectorContext).push<bool>(
+                            MaterialPageRoute(
+                              builder: (_) => RepositoryProvider.value(
+                                value: repository,
+                                child: BlocProvider.value(
+                                  value: bloc,
+                                  child: const AddAddressPage(),
+                                ),
+                              ),
                             ),
-                          ),
-                        ),
+                          );
+                        },
+                        onSaved: () => bloc.add(const RefreshAddresses()),
                       );
                     },
               style: ElevatedButton.styleFrom(
@@ -544,25 +550,39 @@ class _AddressListWithScrollState extends State<_AddressListWithScroll> {
                                 context.read<AddressBookBloc>().add(
                                   SetDefaultAddress(
                                     addressId: numericId,
-
-                                    useForShipping: address.useForShipping,
+                                    firstName: address.firstName,
+                                    lastName: address.lastName,
+                                    address: address.address,
+                                    city: address.city,
+                                    state: address.state,
+                                    country: address.country,
+                                    postcode: address.zipCode,
+                                    phone: address.phone,
+                                    email: address.email,
                                   ),
                                 );
                               }
                             },
-                      onEdit: () {
+                      onEdit: () async {
                         final repository = context.read<AccountRepository>();
                         final bloc = context.read<AddressBookBloc>();
-                        Navigator.of(context).push<bool>(
-                          MaterialPageRoute(
-                            builder: (_) => RepositoryProvider.value(
-                              value: repository,
-                              child: BlocProvider.value(
-                                value: bloc,
-                                child: AddAddressPage(editingAddress: address),
+                        await refreshAddressBookAfterForm(
+                          openForm: () {
+                            return Navigator.of(context).push<bool>(
+                              MaterialPageRoute(
+                                builder: (_) => RepositoryProvider.value(
+                                  value: repository,
+                                  child: BlocProvider.value(
+                                    value: bloc,
+                                    child: AddAddressPage(
+                                      editingAddress: address,
+                                    ),
+                                  ),
+                                ),
                               ),
-                            ),
-                          ),
+                            );
+                          },
+                          onSaved: () => bloc.add(const RefreshAddresses()),
                         );
                       },
                       onDelete: () async {

--- a/lib/features/account/presentation/utils/address_debug_payload.dart
+++ b/lib/features/account/presentation/utils/address_debug_payload.dart
@@ -1,0 +1,23 @@
+import '../../data/models/account_models.dart';
+
+Map<String, dynamic> buildEditAddressDebugPayload(CustomerAddress address) {
+  return {
+    'addressId': address.numericId,
+    'id': address.id,
+    'firstName': address.firstName,
+    'lastName': address.lastName,
+    'email': address.email,
+    'companyName': address.companyName,
+    'vatId': address.vatId,
+    'address': address.address,
+    'city': address.city,
+    'state': address.state,
+    'country': address.country,
+    'postcode': address.zipCode,
+    'phone': address.phone,
+    'defaultAddress': address.isDefault,
+    'useForShipping': address.useForShipping,
+    'addressType': address.addressType,
+    'createdAt': address.createdAt,
+  };
+}

--- a/lib/features/account/presentation/utils/address_state_field_behavior.dart
+++ b/lib/features/account/presentation/utils/address_state_field_behavior.dart
@@ -1,0 +1,14 @@
+String resolveStateFieldText({
+  required String savedStateText,
+  String? matchedStateName,
+}) {
+  if (matchedStateName != null && matchedStateName.trim().isNotEmpty) {
+    return matchedStateName;
+  }
+
+  return savedStateText;
+}
+
+bool shouldUseStateDropdown({required List<String> availableStateNames}) {
+  return availableStateNames.isNotEmpty;
+}

--- a/lib/features/account/presentation/widgets/default_addresses_section.dart
+++ b/lib/features/account/presentation/widgets/default_addresses_section.dart
@@ -2,9 +2,10 @@ import 'package:flutter/material.dart';
 import '../../../../core/theme/app_theme.dart';
 import '../../../../l10n/app_localizations.dart';
 import '../../data/models/account_models.dart';
+import '../helpers/account_dashboard_helpers.dart';
 import 'section_header.dart';
 
-/// Default Addresses section (Billing + Shipping)
+/// Default address section
 /// Figma: node-id=220-7109
 class DefaultAddressesSection extends StatelessWidget {
   final List<CustomerAddress> addresses;
@@ -19,27 +20,7 @@ class DefaultAddressesSection extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     final l10n = AppLocalizations.of(context)!;
-
-    // Find default billing and shipping addresses
-    CustomerAddress? billingAddress;
-    CustomerAddress? shippingAddress;
-
-    for (final address in addresses) {
-      if (address.isDefault) {
-        billingAddress ??= address;
-        if (billingAddress != address) {
-          shippingAddress ??= address;
-        }
-      }
-    }
-
-    // If no default addresses found, use first two
-    if (billingAddress == null && addresses.isNotEmpty) {
-      billingAddress = addresses.first;
-    }
-    if (shippingAddress == null && addresses.length > 1) {
-      shippingAddress = addresses[1];
-    }
+    final defaultAddress = resolveDashboardDefaultAddress(addresses);
 
     return Padding(
       padding: const EdgeInsets.only(top: 24),
@@ -50,35 +31,16 @@ class DefaultAddressesSection extends StatelessWidget {
             padding: const EdgeInsets.symmetric(horizontal: 20),
             child: SectionHeader(
               title: l10n.accountDefaultAddresses,
-              onViewAll: addresses.isNotEmpty
-                  ? onViewAll
-                  : null,
+              onViewAll: addresses.isNotEmpty ? onViewAll : null,
             ),
           ),
           const SizedBox(height: 2),
           if (addresses.isEmpty)
             _buildEmptyState(context)
-          else
+          else if (defaultAddress != null)
             Padding(
               padding: const EdgeInsets.symmetric(horizontal: 20),
-              child: Column(
-                children: [
-                  if (billingAddress != null)
-                    _buildAddressCard(
-                      context,
-                      address: billingAddress,
-                      type: l10n.accountBillingAddress,
-                    ),
-                  if (shippingAddress != null) ...[
-                    const SizedBox(height: 8),
-                    _buildAddressCard(
-                      context,
-                      address: shippingAddress,
-                      type: l10n.accountShippingAddress,
-                    ),
-                  ],
-                ],
-              ),
+              child: _buildAddressCard(context, address: defaultAddress),
             ),
         ],
       ),
@@ -117,7 +79,6 @@ class DefaultAddressesSection extends StatelessWidget {
   Widget _buildAddressCard(
     BuildContext context, {
     required CustomerAddress address,
-    required String type,
   }) {
     final isDark = Theme.of(context).brightness == Brightness.dark;
 
@@ -134,28 +95,10 @@ class DefaultAddressesSection extends StatelessWidget {
       child: Column(
         crossAxisAlignment: CrossAxisAlignment.start,
         children: [
-          // Address type + Default badge
-          Row(
-            children: [
-              Text(
-                type,
-                style: TextStyle(
-                  fontFamily: 'Roboto',
-                  fontWeight: FontWeight.w400,
-                  fontSize: 14,
-                  color: isDark
-                      ? AppColors.neutral300
-                      : AppColors.neutral900,
-                ),
-              ),
-              if (address.isDefault) ...[
-                const SizedBox(width: 4),
-                _buildDefaultBadge(context),
-              ],
-            ],
-          ),
-          const SizedBox(height: 6),
-          // Full name with company
+          if (address.isDefault) ...[
+            _buildDefaultBadge(context),
+            const SizedBox(height: 8),
+          ],
           Text(
             address.fullName,
             style: TextStyle(
@@ -166,7 +109,6 @@ class DefaultAddressesSection extends StatelessWidget {
             ),
           ),
           const SizedBox(height: 6),
-          // Full address
           Text(
             address.formattedAddress,
             style: TextStyle(

--- a/lib/features/checkout/data/repository/checkout_repository.dart
+++ b/lib/features/checkout/data/repository/checkout_repository.dart
@@ -1,9 +1,95 @@
-import 'package:flutter/material.dart';
+import 'dart:convert';
+
+import 'package:flutter/foundation.dart';
 import 'package:graphql_flutter/graphql_flutter.dart';
 import '../../../../core/graphql/graphql_client.dart';
 import '../../../../core/graphql/checkout_queries.dart';
 import '../../../../core/graphql/account_queries.dart';
 import '../models/checkout_model.dart';
+
+List<Map<String, dynamic>> buildCustomerAddressBookInputsFromCheckout(
+  Map<String, dynamic> checkoutInput, {
+  bool defaultAddress = false,
+}) {
+  final usesBillingForShipping = checkoutInput['useForShipping'] == true;
+  final inputs = <Map<String, dynamic>>[
+    _buildCustomerAddressBookInput(
+      checkoutInput,
+      prefix: 'billing',
+      defaultAddress: defaultAddress,
+      useForShipping: usesBillingForShipping,
+    ),
+  ];
+
+  if (!usesBillingForShipping) {
+    inputs.add(
+      _buildCustomerAddressBookInput(
+        checkoutInput,
+        prefix: 'shipping',
+        defaultAddress: false,
+        useForShipping: true,
+      ),
+    );
+  }
+
+  return inputs;
+}
+
+Map<String, dynamic> _buildCustomerAddressBookInput(
+  Map<String, dynamic> checkoutInput, {
+  required String prefix,
+  required bool defaultAddress,
+  required bool useForShipping,
+}) {
+  final input = <String, dynamic>{
+    'firstName': _checkoutInputValue(checkoutInput, '${prefix}FirstName'),
+    'lastName': _checkoutInputValue(checkoutInput, '${prefix}LastName'),
+    'address1': _checkoutInputValue(checkoutInput, '${prefix}Address'),
+    'city': _checkoutInputValue(checkoutInput, '${prefix}City'),
+    'state': _checkoutInputValue(checkoutInput, '${prefix}State'),
+    'country': _checkoutInputValue(checkoutInput, '${prefix}Country'),
+    'postcode': _checkoutInputValue(checkoutInput, '${prefix}Postcode'),
+    'phone': _checkoutInputValue(checkoutInput, '${prefix}PhoneNumber'),
+    'defaultAddress': defaultAddress,
+    'useForShipping': useForShipping,
+  };
+
+  final email = _checkoutInputValue(checkoutInput, '${prefix}Email');
+  if (email.isNotEmpty) {
+    input['email'] = email;
+  }
+
+  return input;
+}
+
+String _checkoutInputValue(Map<String, dynamic> checkoutInput, String key) {
+  return checkoutInput[key]?.toString() ?? '';
+}
+
+bool shouldLogCheckoutOperation(String operation) {
+  return operation != 'getCountries';
+}
+
+void _logCheckoutApiDetails(
+  String operation, {
+  Map<String, dynamic>? variables,
+  Object? responseData,
+}) {
+  if (!kDebugMode || !shouldLogCheckoutOperation(operation)) return;
+
+  final encoder = const JsonEncoder.withIndent('  ');
+  debugPrint('━━━━━━━━━━━━━━━━ Checkout API ━━━━━━━━━━━━━━━━');
+  debugPrint('[CheckoutRepo][$operation]');
+  if (variables != null) {
+    debugPrint('variables=');
+    debugPrint(encoder.convert(variables));
+  }
+  if (responseData != null) {
+    debugPrint('response=');
+    debugPrint(encoder.convert(responseData));
+  }
+  debugPrint('━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━');
+}
 
 /// Repository for all checkout operations via Bagisto GraphQL API.
 ///
@@ -67,7 +153,6 @@ class CheckoutRepository {
   /// Fetch all available countries from the Bagisto API.
   /// API: https://api-docs.bagisto.com/api/graphql-api/shop/queries/get-countries.html
   Future<List<BagistoCountry>> getCountries() async {
-    debugPrint('[CheckoutRepo] getCountries...');
     final result = await _authedClient.query(
       QueryOptions(
         document: gql(CheckoutQueries.getCountries),
@@ -79,6 +164,8 @@ class CheckoutRepository {
       debugPrint('[CheckoutRepo] getCountries error: ${result.exception}');
       throw result.exception!;
     }
+
+    _logCheckoutApiDetails('getCountries', responseData: result.data);
 
     final edges = result.data?['countries']?['edges'] as List?;
     if (edges == null) return [];
@@ -141,6 +228,12 @@ class CheckoutRepository {
       }
       return [];
     }
+
+    _logCheckoutApiDetails(
+      'getCountryStates',
+      variables: variables,
+      responseData: result.data,
+    );
 
     final statesData = result.data?['countryStates'];
     if (statesData == null) {
@@ -220,6 +313,12 @@ class CheckoutRepository {
       return [];
     }
 
+    _logCheckoutApiDetails(
+      'getCountryStatesByCode',
+      variables: {'countryCode': countryCode, 'first': 200},
+      responseData: result.data,
+    );
+
     final statesData = result.data?['countryStates'];
     if (statesData == null) {
       debugPrint(
@@ -270,6 +369,8 @@ class CheckoutRepository {
       throw result.exception!;
     }
 
+    _logCheckoutApiDetails('getCheckoutAddresses', responseData: result.data);
+
     final edges =
         result.data?['collectionGetCheckoutAddresses']?['edges'] as List?;
     if (edges == null) return [];
@@ -301,6 +402,12 @@ class CheckoutRepository {
       );
       throw result.exception!;
     }
+
+    _logCheckoutApiDetails(
+      'getCustomerAddresses',
+      variables: {'first': 100},
+      responseData: result.data,
+    );
 
     final edges = result.data?['getCustomerAddresses']?['edges'] as List?;
     if (edges == null) return [];
@@ -363,6 +470,12 @@ class CheckoutRepository {
       throw result.exception!;
     }
 
+    _logCheckoutApiDetails(
+      'getShippingRates',
+      variables: {'token': qToken},
+      responseData: result.data,
+    );
+
     final list = result.data?['collectionShippingRates'] as List?;
     if (list == null) return [];
 
@@ -394,6 +507,12 @@ class CheckoutRepository {
       throw result.exception!;
     }
 
+    _logCheckoutApiDetails(
+      'getPaymentMethods',
+      variables: {'token': qToken},
+      responseData: result.data,
+    );
+
     final list = result.data?['collectionPaymentMethods'] as List?;
     if (list == null) return [];
 
@@ -423,6 +542,12 @@ class CheckoutRepository {
       throw result.exception!;
     }
 
+    _logCheckoutApiDetails(
+      'saveCheckoutAddress',
+      variables: {'input': input},
+      responseData: result.data,
+    );
+
     final data =
         result.data?['createCheckoutAddress']?['checkoutAddress']
             as Map<String, dynamic>?;
@@ -441,45 +566,40 @@ class CheckoutRepository {
     Map<String, dynamic> checkoutInput, {
     bool defaultAddress = false,
   }) async {
-    final input = <String, dynamic>{
-      'firstName': checkoutInput['billingFirstName']?.toString() ?? '',
-      'lastName': checkoutInput['billingLastName']?.toString() ?? '',
-      'address1': checkoutInput['billingAddress']?.toString() ?? '',
-      'city': checkoutInput['billingCity']?.toString() ?? '',
-      'state': checkoutInput['billingState']?.toString() ?? '',
-      'country': checkoutInput['billingCountry']?.toString() ?? '',
-      'postcode': checkoutInput['billingPostcode']?.toString() ?? '',
-      'phone': checkoutInput['billingPhoneNumber']?.toString() ?? '',
-      'defaultAddress': defaultAddress,
-      'useForShipping': checkoutInput['useForShipping'] == true,
-    };
-
-    final email = checkoutInput['billingEmail']?.toString() ?? '';
-    if (email.isNotEmpty) {
-      input['email'] = email;
-    }
-
-    debugPrint('[CheckoutRepo] saveCustomerAddressFromCheckout input=$input');
-
-    final result = await _authedClient.mutate(
-      MutationOptions(
-        document: gql(AccountQueries.createAddUpdateCustomerAddress),
-        variables: {'input': input},
-      ),
+    final inputs = buildCustomerAddressBookInputsFromCheckout(
+      checkoutInput,
+      defaultAddress: defaultAddress,
     );
 
-    if (result.hasException) {
-      debugPrint(
-        '[CheckoutRepo] saveCustomerAddressFromCheckout error: ${result.exception}',
-      );
-      throw result.exception!;
-    }
+    for (final input in inputs) {
+      debugPrint('[CheckoutRepo] saveCustomerAddressFromCheckout input=$input');
 
-    final data =
-        result.data?['createAddUpdateCustomerAddress']?['addUpdateCustomerAddress']
-            as Map<String, dynamic>?;
-    if (data == null) {
-      throw Exception('Failed to save address to address book');
+      final result = await _authedClient.mutate(
+        MutationOptions(
+          document: gql(AccountQueries.createAddUpdateCustomerAddress),
+          variables: {'input': input},
+        ),
+      );
+
+      if (result.hasException) {
+        debugPrint(
+          '[CheckoutRepo] saveCustomerAddressFromCheckout error: ${result.exception}',
+        );
+        throw result.exception!;
+      }
+
+      _logCheckoutApiDetails(
+        'saveCustomerAddressFromCheckout',
+        variables: {'input': input},
+        responseData: result.data,
+      );
+
+      final data =
+          result.data?['createAddUpdateCustomerAddress']?['addUpdateCustomerAddress']
+              as Map<String, dynamic>?;
+      if (data == null) {
+        throw Exception('Failed to save address to address book');
+      }
     }
   }
 
@@ -505,6 +625,14 @@ class CheckoutRepository {
       );
       throw result.exception!;
     }
+
+    _logCheckoutApiDetails(
+      'saveShippingMethod',
+      variables: {
+        'input': {'shippingMethod': shippingMethod},
+      },
+      responseData: result.data,
+    );
 
     final data =
         result.data?['createCheckoutShippingMethod']?['checkoutShippingMethod']
@@ -535,6 +663,14 @@ class CheckoutRepository {
       throw result.exception!;
     }
 
+    _logCheckoutApiDetails(
+      'savePaymentMethod',
+      variables: {
+        'input': {'paymentMethod': paymentMethod},
+      },
+      responseData: result.data,
+    );
+
     final data =
         result.data?['createCheckoutPaymentMethod']?['checkoutPaymentMethod']
             as Map<String, dynamic>?;
@@ -556,6 +692,8 @@ class CheckoutRepository {
       debugPrint('[CheckoutRepo] placeOrder error: ${result.exception}');
       throw result.exception!;
     }
+
+    _logCheckoutApiDetails('placeOrder', responseData: result.data);
 
     final data =
         result.data?['createCheckoutOrder']?['checkoutOrder']
@@ -584,6 +722,14 @@ class CheckoutRepository {
       throw result.exception!;
     }
 
+    _logCheckoutApiDetails(
+      'applyCoupon',
+      variables: {
+        'input': {'couponCode': couponCode},
+      },
+      responseData: result.data,
+    );
+
     final data =
         result.data?['createApplyCoupon']?['applyCoupon']
             as Map<String, dynamic>?;
@@ -608,6 +754,12 @@ class CheckoutRepository {
       debugPrint('[CheckoutRepo] removeCoupon error: ${result.exception}');
       throw result.exception!;
     }
+
+    _logCheckoutApiDetails(
+      'removeCoupon',
+      variables: {'input': {}},
+      responseData: result.data,
+    );
 
     final data =
         result.data?['createRemoveCoupon']?['removeCoupon']

--- a/lib/features/checkout/presentation/bloc/checkout_bloc.dart
+++ b/lib/features/checkout/presentation/bloc/checkout_bloc.dart
@@ -161,6 +161,7 @@ class CheckoutState extends Equatable {
   // Addresses fetched from API (only for logged-in users)
   final List<CheckoutAddress> addresses;
   final CheckoutAddress? selectedAddress;
+  final CheckoutAddress? selectedShippingAddress;
   final bool useSameAddressForShipping;
 
   // Shipping rates (fetched after address saved)
@@ -196,6 +197,7 @@ class CheckoutState extends Equatable {
     this.addressConfirmed = false,
     this.addresses = const [],
     this.selectedAddress,
+    this.selectedShippingAddress,
     this.useSameAddressForShipping = true,
     this.shippingRates = const [],
     this.selectedShippingMethod,
@@ -230,6 +232,7 @@ class CheckoutState extends Equatable {
     bool? addressConfirmed,
     List<CheckoutAddress>? addresses,
     CheckoutAddress? selectedAddress,
+    CheckoutAddress? selectedShippingAddress,
     bool? useSameAddressForShipping,
     List<ShippingRate>? shippingRates,
     String? selectedShippingMethod,
@@ -250,6 +253,7 @@ class CheckoutState extends Equatable {
     bool clearError = false,
     bool clearSuccess = false,
     bool clearSelectedAddress = false,
+    bool clearSelectedShippingAddress = false,
     bool clearSelectedShippingMethod = false,
     bool clearSelectedPaymentMethod = false,
   }) {
@@ -263,6 +267,9 @@ class CheckoutState extends Equatable {
       selectedAddress: clearSelectedAddress
           ? null
           : (selectedAddress ?? this.selectedAddress),
+      selectedShippingAddress: clearSelectedShippingAddress
+          ? null
+          : (selectedShippingAddress ?? this.selectedShippingAddress),
       useSameAddressForShipping:
           useSameAddressForShipping ?? this.useSameAddressForShipping,
       shippingRates: shippingRates ?? this.shippingRates,
@@ -300,6 +307,7 @@ class CheckoutState extends Equatable {
     addressConfirmed,
     addresses,
     selectedAddress,
+    selectedShippingAddress,
     useSameAddressForShipping,
     shippingRates,
     selectedShippingMethod,
@@ -444,6 +452,10 @@ class CheckoutBloc extends Bloc<CheckoutEvent, CheckoutState> {
         (a) => a.addressType == 'cart_billing',
         orElse: () => const CheckoutAddress(id: ''),
       );
+      final cartShipping = addresses.firstWhere(
+        (a) => a.addressType == 'cart_shipping',
+        orElse: () => const CheckoutAddress(id: ''),
+      );
       final hasCartAddress = cartBilling.id.isNotEmpty;
 
       CheckoutAddress? defaultAddr;
@@ -470,6 +482,10 @@ class CheckoutBloc extends Bloc<CheckoutEvent, CheckoutState> {
                   ? customerAddresses
                   : addresses,
               selectedAddress: defaultAddr,
+              selectedShippingAddress: defaultAddr.useForShipping
+                  ? null
+                  : (cartShipping.id.isNotEmpty ? cartShipping : null),
+              useSameAddressForShipping: defaultAddr.useForShipping,
               status: CheckoutStatus.addressSaved,
               addressConfirmed: true,
               isLoading: false,
@@ -576,6 +592,7 @@ class CheckoutBloc extends Bloc<CheckoutEvent, CheckoutState> {
                     ? customerAddresses
                     : addresses,
                 selectedAddress: defaultAddr,
+                useSameAddressForShipping: true,
                 status: CheckoutStatus.addressSaved,
                 addressConfirmed: true,
                 cartToken: queryToken,
@@ -716,6 +733,7 @@ class CheckoutBloc extends Bloc<CheckoutEvent, CheckoutState> {
                 state.copyWith(
                   addresses: accountAddresses,
                   selectedAddress: fallbackAddr,
+                  useSameAddressForShipping: true,
                   status: CheckoutStatus.addressSaved,
                   addressConfirmed: true,
                   cartToken: fallbackQueryToken,
@@ -866,6 +884,10 @@ class CheckoutBloc extends Bloc<CheckoutEvent, CheckoutState> {
     emit(
       state.copyWith(
         selectedAddress: event.address,
+        selectedShippingAddress: event.useForShipping
+            ? null
+            : event.shippingAddress,
+        useSameAddressForShipping: event.useForShipping,
         // Reset downstream steps since address changed
         addressConfirmed: false,
         shippingRates: const [],
@@ -1124,10 +1146,25 @@ class CheckoutBloc extends Bloc<CheckoutEvent, CheckoutState> {
         }
       }
 
+      final selectedBillingAddress =
+          state.selectedAddress ??
+          buildCheckoutAddressFromInput(input: event.input, prefix: 'billing');
+      final useSameAddressForShipping = event.input['useForShipping'] == true;
+      final selectedShippingAddress = useSameAddressForShipping
+          ? null
+          : (state.selectedShippingAddress ??
+                buildCheckoutAddressFromInput(
+                  input: event.input,
+                  prefix: 'shipping',
+                ));
+
       emit(
         state.copyWith(
           status: CheckoutStatus.addressSaved,
           cartToken: queryToken,
+          selectedAddress: selectedBillingAddress,
+          selectedShippingAddress: selectedShippingAddress,
+          useSameAddressForShipping: useSameAddressForShipping,
           addressConfirmed: true,
           addresses: refreshedAddresses,
           successMessage: response.message,
@@ -1487,11 +1524,31 @@ class CheckoutBloc extends Bloc<CheckoutEvent, CheckoutState> {
       return;
     }
 
-    emit(
-      state.copyWith(
-        useSameAddressForShipping: !state.useSameAddressForShipping,
-      ),
-    );
+    final nextUseSameAddress = !state.useSameAddressForShipping;
+
+    // Confirmed saved-address checkout has no save button on the card, so the
+    // toggle itself must persist the updated billing/shipping relationship.
+    if (state.addressConfirmed &&
+        state.selectedAddress != null &&
+        state.addresses.isNotEmpty) {
+      final shippingAddress = nextUseSameAddress
+          ? null
+          : state.selectedShippingAddress ??
+                (state.addresses.length > 1
+                    ? state.addresses[1]
+                    : state.addresses.first);
+
+      add(
+        SelectSavedAddress(
+          address: state.selectedAddress!,
+          useForShipping: nextUseSameAddress,
+          shippingAddress: shippingAddress,
+        ),
+      );
+      return;
+    }
+
+    emit(state.copyWith(useSameAddressForShipping: nextUseSameAddress));
   }
 
   void _onResetAddressConfirmation(
@@ -1501,6 +1558,7 @@ class CheckoutBloc extends Bloc<CheckoutEvent, CheckoutState> {
     emit(
       state.copyWith(
         addressConfirmed: false,
+        clearSelectedShippingAddress: true,
         shippingRates: const [],
         clearSelectedShippingMethod: true,
         paymentMethods: const [],

--- a/lib/features/checkout/presentation/helpers/checkout_address_sheet_helpers.dart
+++ b/lib/features/checkout/presentation/helpers/checkout_address_sheet_helpers.dart
@@ -1,5 +1,28 @@
 import '../../data/models/checkout_model.dart';
 
+bool shouldRefreshAddressesBeforeShowingChangeSheet({
+  required bool isGuest,
+  required bool addressConfirmed,
+}) {
+  return !isGuest && addressConfirmed;
+}
+
+Future<List<CheckoutAddress>> loadChangeAddressSheetAddresses({
+  required bool isGuest,
+  required List<CheckoutAddress> currentAddresses,
+  required Future<List<CheckoutAddress>> Function() refreshAddresses,
+}) async {
+  if (isGuest) {
+    return currentAddresses;
+  }
+
+  try {
+    return await refreshAddresses();
+  } catch (_) {
+    return currentAddresses;
+  }
+}
+
 String? findNewlyAddedAddressId({
   required Set<String> previousIds,
   required Iterable<String?> refreshedIds,
@@ -86,4 +109,23 @@ Map<String, dynamic> buildSavedCheckoutAddressInput({
   }
 
   return input;
+}
+
+CheckoutAddress buildCheckoutAddressFromInput({
+  required Map<String, dynamic> input,
+  required String prefix,
+}) {
+  return CheckoutAddress(
+    id: '',
+    firstName: input['${prefix}FirstName']?.toString() ?? '',
+    lastName: input['${prefix}LastName']?.toString() ?? '',
+    email: input['${prefix}Email']?.toString(),
+    companyName: input['${prefix}CompanyName']?.toString(),
+    address: input['${prefix}Address']?.toString() ?? '',
+    city: input['${prefix}City']?.toString() ?? '',
+    state: input['${prefix}State']?.toString(),
+    country: input['${prefix}Country']?.toString(),
+    postcode: input['${prefix}Postcode']?.toString(),
+    phone: input['${prefix}PhoneNumber']?.toString(),
+  );
 }

--- a/lib/features/checkout/presentation/pages/checkout_page.dart
+++ b/lib/features/checkout/presentation/pages/checkout_page.dart
@@ -19,6 +19,7 @@ import '../../data/repository/checkout_repository.dart';
 import '../bloc/checkout_bloc.dart';
 import '../helpers/checkout_address_sheet_helpers.dart';
 import '../widgets/checkout_address_selection_sheet.dart';
+import '../widgets/checkout_interaction_blocker.dart';
 import 'thankyou_page.dart';
 
 class CheckoutPage extends StatelessWidget {
@@ -87,16 +88,15 @@ class _CheckoutPageView extends StatefulWidget {
 
 class _CheckoutPageViewState extends State<_CheckoutPageView> {
   final TextEditingController _couponController = TextEditingController();
-  bool _useSameAddress = true;
   bool _saveToAddressBook = true;
 
   bool _requiresShipping(CheckoutState state) => !state.isVirtualOnly;
 
   bool _usesBillingAsShipping(CheckoutState state) =>
-      state.isVirtualOnly || _useSameAddress;
+      state.isVirtualOnly || state.useSameAddressForShipping;
 
   bool _showsSeparateShippingForm(CheckoutState state) =>
-      _requiresShipping(state) && !_useSameAddress;
+      _requiresShipping(state) && !state.useSameAddressForShipping;
 
   bool _shouldOfferSaveToAddressBook(CheckoutState state) =>
       !state.isGuest && state.addresses.isEmpty;
@@ -163,6 +163,7 @@ class _CheckoutPageViewState extends State<_CheckoutPageView> {
     if (state.addresses.isEmpty) return null;
 
     return _selectedShippingAddress ??
+        state.selectedShippingAddress ??
         (state.addresses.length > 1
             ? state.addresses[1]
             : state.addresses.first);
@@ -385,6 +386,11 @@ class _CheckoutPageViewState extends State<_CheckoutPageView> {
               _selectedBillingAddress == null) {
             _selectedBillingAddress = state.selectedAddress;
           }
+          if (state.selectedShippingAddress != null &&
+              _selectedShippingAddress?.id !=
+                  state.selectedShippingAddress?.id) {
+            _selectedShippingAddress = state.selectedShippingAddress;
+          }
           // Reset local selections when bloc resets downstream state
           if (!state.addressConfirmed) {
             _selectedShippingMethod = null;
@@ -406,89 +412,99 @@ class _CheckoutPageViewState extends State<_CheckoutPageView> {
           if (state.selectedPaymentMethod == null) {
             _selectedPaymentMethod = null;
           }
-          if (state.isVirtualOnly && !_useSameAddress) {
-            setState(() => _useSameAddress = true);
-          }
         },
         builder: (context, state) {
           final isDark = Theme.of(context).brightness == Brightness.dark;
           final cart = state.cart;
-          return Scaffold(
-            backgroundColor: isDark ? AppColors.neutral900 : AppColors.white,
-            body: SafeArea(
-              bottom: false,
-              child: Column(
-                children: [
-                  _buildAppBar(context),
-                  Expanded(
-                    child: SingleChildScrollView(
-                      physics: const BouncingScrollPhysics(),
-                      child: Column(
-                        crossAxisAlignment: CrossAxisAlignment.start,
-                        children: [
-                          const SizedBox(height: 16),
-                          // Billing Address
-                          Padding(
-                            padding: const EdgeInsets.symmetric(horizontal: 20),
-                            child: _buildBillingSection(context, state),
-                          ),
-                          const SizedBox(height: 16),
-                          // Shipping Address (only when NOT using same address and NOT virtual only)
-                          if (_showsSeparateShippingForm(state)) ...[
+          return CheckoutInteractionBlocker(
+            isBlocking: state.isPlacingOrder,
+            child: Scaffold(
+              backgroundColor: isDark ? AppColors.neutral900 : AppColors.white,
+              body: SafeArea(
+                bottom: false,
+                child: Column(
+                  children: [
+                    _buildAppBar(context),
+                    Expanded(
+                      child: SingleChildScrollView(
+                        physics: const BouncingScrollPhysics(),
+                        child: Column(
+                          crossAxisAlignment: CrossAxisAlignment.start,
+                          children: [
+                            const SizedBox(height: 16),
+                            // Billing Address
                             Padding(
                               padding: const EdgeInsets.symmetric(
                                 horizontal: 20,
                               ),
-                              child: _buildShippingAddressSection(
-                                context,
-                                state,
-                              ),
+                              child: _buildBillingSection(context, state),
                             ),
                             const SizedBox(height: 16),
-                          ],
-                          // Cart Items
-                          Padding(
-                            padding: const EdgeInsets.symmetric(horizontal: 20),
-                            child: _buildCartItemsSection(context, cart),
-                          ),
-                          const SizedBox(height: 16),
-                          // Shipping Method (only when NOT virtual only)
-                          if (!state.isVirtualOnly) ...[
+                            // Shipping Address (only when NOT using same address and NOT virtual only)
+                            if (_showsSeparateShippingForm(state)) ...[
+                              Padding(
+                                padding: const EdgeInsets.symmetric(
+                                  horizontal: 20,
+                                ),
+                                child: _buildShippingAddressSection(
+                                  context,
+                                  state,
+                                ),
+                              ),
+                              const SizedBox(height: 16),
+                            ],
+                            // Cart Items
                             Padding(
                               padding: const EdgeInsets.symmetric(
                                 horizontal: 20,
                               ),
-                              child: _buildShippingMethodSection(
-                                context,
-                                state,
-                              ),
+                              child: _buildCartItemsSection(context, cart),
                             ),
-                            const SizedBox(height: 8),
+                            const SizedBox(height: 16),
+                            // Shipping Method (only when NOT virtual only)
+                            if (!state.isVirtualOnly) ...[
+                              Padding(
+                                padding: const EdgeInsets.symmetric(
+                                  horizontal: 20,
+                                ),
+                                child: _buildShippingMethodSection(
+                                  context,
+                                  state,
+                                ),
+                              ),
+                              const SizedBox(height: 8),
+                            ],
+                            // Payment Method
+                            Padding(
+                              padding: const EdgeInsets.symmetric(
+                                horizontal: 20,
+                              ),
+                              child: _buildPaymentMethodSection(context, state),
+                            ),
+                            const SizedBox(height: 32),
+                            // Coupon
+                            Padding(
+                              padding: const EdgeInsets.symmetric(
+                                horizontal: 20,
+                              ),
+                              child: _buildCouponSection(context, state),
+                            ),
+                            const SizedBox(height: 32),
+                            // Price Break
+                            Padding(
+                              padding: const EdgeInsets.symmetric(
+                                horizontal: 20,
+                              ),
+                              child: _buildPriceBreakSection(context, cart),
+                            ),
+                            const SizedBox(height: 100),
                           ],
-                          // Payment Method
-                          Padding(
-                            padding: const EdgeInsets.symmetric(horizontal: 20),
-                            child: _buildPaymentMethodSection(context, state),
-                          ),
-                          const SizedBox(height: 32),
-                          // Coupon
-                          Padding(
-                            padding: const EdgeInsets.symmetric(horizontal: 20),
-                            child: _buildCouponSection(context, state),
-                          ),
-                          const SizedBox(height: 32),
-                          // Price Break
-                          Padding(
-                            padding: const EdgeInsets.symmetric(horizontal: 20),
-                            child: _buildPriceBreakSection(context, cart),
-                          ),
-                          const SizedBox(height: 100),
-                        ],
+                        ),
                       ),
                     ),
-                  ),
-                  _buildBottomBar(context, cart, state),
-                ],
+                    _buildBottomBar(context, cart, state),
+                  ],
+                ),
               ),
             ),
           );
@@ -617,8 +633,7 @@ class _CheckoutPageViewState extends State<_CheckoutPageView> {
         state: state,
         label: AppLocalizations.of(context)!.checkoutDeliveredTo,
         address: shippingAddress,
-        onChangePressed: () =>
-            _showAddressSelectionSheet(context, state, isBilling: false),
+        onChangePressed: () => _showShippingChangeAddressFlow(context, state),
         showSameAddressCheckbox: false,
       );
     }
@@ -647,7 +662,7 @@ class _CheckoutPageViewState extends State<_CheckoutPageView> {
       child: Column(
         crossAxisAlignment: CrossAxisAlignment.start,
         children: [
-          _buildAddressTitleRow(label, address, onChangePressed, isDark),
+          _buildAddressTitleRow(label, onChangePressed, isDark),
           const SizedBox(height: 6),
           Text(
             address.displayName,
@@ -700,7 +715,7 @@ class _CheckoutPageViewState extends State<_CheckoutPageView> {
       child: Column(
         crossAxisAlignment: CrossAxisAlignment.start,
         children: [
-          _buildAddressTitleRow(label, address, onChangePressed, isDark),
+          _buildAddressTitleRow(label, onChangePressed, isDark),
           const SizedBox(height: 6),
           Text(
             address.displayName,
@@ -748,33 +763,23 @@ class _CheckoutPageViewState extends State<_CheckoutPageView> {
     );
   }
 
-  /// Title row: label + green chip + "Change"
+  /// Title row: label + "Change"
   Widget _buildAddressTitleRow(
     String label,
-    CheckoutAddress address,
     VoidCallback onChangePressed,
     bool isDark,
   ) {
-    final chipText = _getAddressTypeChip(address);
     return Row(
       mainAxisAlignment: MainAxisAlignment.spaceBetween,
       children: [
-        Row(
-          children: [
-            Text(
-              label,
-              style: TextStyle(
-                fontFamily: 'Roboto',
-                fontWeight: FontWeight.w400,
-                fontSize: 14,
-                color: isDark ? AppColors.neutral300 : AppColors.neutral900,
-              ),
-            ),
-            if (chipText.isNotEmpty) ...[
-              const SizedBox(width: 4),
-              _buildGreenChip(chipText),
-            ],
-          ],
+        Text(
+          label,
+          style: TextStyle(
+            fontFamily: 'Roboto',
+            fontWeight: FontWeight.w400,
+            fontSize: 14,
+            color: isDark ? AppColors.neutral300 : AppColors.neutral900,
+          ),
         ),
         GestureDetector(
           onTap: onChangePressed,
@@ -790,47 +795,6 @@ class _CheckoutPageViewState extends State<_CheckoutPageView> {
         ),
       ],
     );
-  }
-
-  /// Green badge chip (Figma node 233:5469)
-  Widget _buildGreenChip(String text) {
-    return Container(
-      padding: const EdgeInsets.symmetric(horizontal: 6, vertical: 4),
-      decoration: BoxDecoration(
-        color: const Color(0xFFDCFCE7),
-        border: Border.all(color: const Color(0xFFB9F8CF)),
-        borderRadius: BorderRadius.circular(6),
-      ),
-      child: Text(
-        text,
-        style: const TextStyle(
-          fontFamily: 'Roboto',
-          fontWeight: FontWeight.w700,
-          fontSize: 12,
-          color: Color(0xFF00A63E),
-        ),
-      ),
-    );
-  }
-
-  String _getAddressTypeChip(CheckoutAddress address) {
-    final l10n = AppLocalizations.of(context)!;
-    final type = address.addressType.toLowerCase();
-    if (type.contains('office') || type.contains('work')) {
-      return l10n.checkoutAddressTypeOffice;
-    }
-    if (type.contains('home')) return l10n.checkoutAddressTypeHome;
-    if (type.contains('billing') || type.contains('cart_billing')) {
-      return l10n.checkoutAddressTypeBilling;
-    }
-    if (type.contains('shipping') || type.contains('cart_shipping')) {
-      return l10n.checkoutAddressTypeShipping;
-    }
-    if (address.defaultAddress) return l10n.checkoutAddressTypeDefault;
-    if (address.companyName != null && address.companyName!.isNotEmpty) {
-      return l10n.checkoutAddressTypeOffice;
-    }
-    return l10n.checkoutAddressTypeHome;
   }
 
   Widget _buildSelectAddressPrompt(
@@ -885,9 +849,10 @@ class _CheckoutPageViewState extends State<_CheckoutPageView> {
     BuildContext context,
     CheckoutState state, {
     required bool isBilling,
+    List<CheckoutAddress>? addressesOverride,
   }) {
     final pageContext = context;
-    final addresses = state.addresses;
+    final addresses = addressesOverride ?? state.addresses;
     if (addresses.isEmpty) return;
 
     final isDark = Theme.of(pageContext).brightness == Brightness.dark;
@@ -924,7 +889,6 @@ class _CheckoutPageViewState extends State<_CheckoutPageView> {
                   ? _currentBillingAddress(state)?.id
                   : _currentShippingAddress(state)?.id,
               scrollController: scrollController,
-              addressTypeLabelBuilder: _getAddressTypeChip,
               phoneLabelBuilder: AppLocalizations.of(
                 pageContext,
               )!.checkoutPhoneValue,
@@ -957,17 +921,47 @@ class _CheckoutPageViewState extends State<_CheckoutPageView> {
     );
   }
 
-  void _showChangeAddressFlow(
+  Future<void> _showChangeAddressFlow(
     BuildContext context,
     CheckoutState state, {
     required bool isBilling,
-  }) {
-    if (state.isGuest || state.addresses.isEmpty) {
-      // Guest or logged-in with no saved addresses: reset to form
-      context.read<CheckoutBloc>().add(ResetAddressConfirmation());
-    } else {
+  }) async {
+    if (!shouldRefreshAddressesBeforeShowingChangeSheet(
+      isGuest: state.isGuest,
+      addressConfirmed: state.addressConfirmed,
+    )) {
+      if (state.isGuest) {
+        // Guest checkout still returns to the form.
+        context.read<CheckoutBloc>().add(ResetAddressConfirmation());
+        return;
+      }
+
       _showAddressSelectionSheet(context, state, isBilling: isBilling);
+      return;
     }
+
+    final checkoutBloc = context.read<CheckoutBloc>();
+    final addresses = await loadChangeAddressSheetAddresses(
+      isGuest: state.isGuest,
+      currentAddresses: state.addresses,
+      refreshAddresses: () => _refreshSavedAddresses(checkoutBloc),
+    );
+
+    if (!context.mounted) return;
+
+    _showAddressSelectionSheet(
+      context,
+      checkoutBloc.state,
+      isBilling: isBilling,
+      addressesOverride: addresses,
+    );
+  }
+
+  Future<void> _showShippingChangeAddressFlow(
+    BuildContext context,
+    CheckoutState state,
+  ) {
+    return _showChangeAddressFlow(context, state, isBilling: false);
   }
 
   // =====================================================================
@@ -1156,10 +1150,6 @@ class _CheckoutPageViewState extends State<_CheckoutPageView> {
                     fontSize: 14,
                     color: isDark ? AppColors.neutral300 : AppColors.neutral900,
                   ),
-                ),
-                const SizedBox(width: 4),
-                _buildGreenChip(
-                  AppLocalizations.of(context)!.checkoutAddressTypeShipping,
                 ),
               ],
             ),
@@ -1622,9 +1612,11 @@ class _CheckoutPageViewState extends State<_CheckoutPageView> {
   /// Checkbox: "Use same address for shipping?"  (Figma node 204:6691)
   Widget _buildSameAddressCheckbox(BuildContext context) {
     final isDark = Theme.of(context).brightness == Brightness.dark;
+    final useSameAddress = context.select(
+      (CheckoutBloc bloc) => bloc.state.useSameAddressForShipping,
+    );
     return GestureDetector(
       onTap: () {
-        setState(() => _useSameAddress = !_useSameAddress);
         context.read<CheckoutBloc>().add(ToggleSameAddress());
       },
       child: SizedBox(
@@ -1634,7 +1626,7 @@ class _CheckoutPageViewState extends State<_CheckoutPageView> {
             SizedBox(
               width: 24,
               height: 24,
-              child: _useSameAddress
+              child: useSameAddress
                   ? Container(
                       decoration: BoxDecoration(
                         color: AppColors.primary500,
@@ -1803,22 +1795,6 @@ class _CheckoutPageViewState extends State<_CheckoutPageView> {
           'shippingPhoneNumber': _shippingPhoneCtrl.text.trim(),
         });
       }
-
-      // Build address from form for display
-      final formAddr = CheckoutAddress(
-        id: '',
-        firstName: _billingFirstNameCtrl.text.trim(),
-        lastName: _billingLastNameCtrl.text.trim(),
-        companyName: _billingCompanyCtrl.text.trim(),
-        address: _billingAddressCtrl.text.trim(),
-        city: _billingCityCtrl.text.trim(),
-        state: _billingState,
-        country: _billingCountry,
-        postcode: _billingPostcodeCtrl.text.trim(),
-        phone: _billingPhoneCtrl.text.trim(),
-        email: _billingEmailCtrl.text.trim(),
-      );
-      context.read<CheckoutBloc>().add(SelectSavedAddress(address: formAddr));
     } else {
       input = state.selectedAddress!.toBillingInput(
         useForShipping: useSameAddressForShipping,

--- a/lib/features/checkout/presentation/widgets/checkout_address_selection_sheet.dart
+++ b/lib/features/checkout/presentation/widgets/checkout_address_selection_sheet.dart
@@ -11,7 +11,6 @@ class CheckoutAddressSelectionSheet extends StatelessWidget {
   final ScrollController? scrollController;
   final ValueChanged<CheckoutAddress> onAddressSelected;
   final VoidCallback onAddNewAddress;
-  final String Function(CheckoutAddress address) addressTypeLabelBuilder;
   final String Function(String phone) phoneLabelBuilder;
 
   const CheckoutAddressSelectionSheet({
@@ -21,7 +20,6 @@ class CheckoutAddressSelectionSheet extends StatelessWidget {
     required this.addresses,
     required this.onAddressSelected,
     required this.onAddNewAddress,
-    required this.addressTypeLabelBuilder,
     required this.phoneLabelBuilder,
     this.selectedAddressId,
     this.scrollController,
@@ -106,9 +104,6 @@ class CheckoutAddressSelectionSheet extends StatelessWidget {
                                 ),
                               ),
                             ),
-                            _AddressTypeChip(
-                              text: addressTypeLabelBuilder(address),
-                            ),
                           ],
                         ),
                         const SizedBox(height: 4),
@@ -172,33 +167,6 @@ class CheckoutAddressSelectionSheet extends StatelessWidget {
             ),
           ),
         ],
-      ),
-    );
-  }
-}
-
-class _AddressTypeChip extends StatelessWidget {
-  final String text;
-
-  const _AddressTypeChip({required this.text});
-
-  @override
-  Widget build(BuildContext context) {
-    return Container(
-      padding: const EdgeInsets.symmetric(horizontal: 6, vertical: 4),
-      decoration: BoxDecoration(
-        color: const Color(0xFFDCFCE7),
-        border: Border.all(color: const Color(0xFFB9F8CF)),
-        borderRadius: BorderRadius.circular(6),
-      ),
-      child: Text(
-        text,
-        style: const TextStyle(
-          fontFamily: 'Roboto',
-          fontWeight: FontWeight.w700,
-          fontSize: 12,
-          color: Color(0xFF00A63E),
-        ),
       ),
     );
   }

--- a/lib/features/checkout/presentation/widgets/checkout_interaction_blocker.dart
+++ b/lib/features/checkout/presentation/widgets/checkout_interaction_blocker.dart
@@ -1,0 +1,29 @@
+import 'package:flutter/material.dart';
+
+class CheckoutInteractionBlocker extends StatelessWidget {
+  final bool isBlocking;
+  final Widget child;
+
+  const CheckoutInteractionBlocker({
+    super.key,
+    required this.isBlocking,
+    required this.child,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return Stack(
+      children: [
+        AbsorbPointer(absorbing: isBlocking, child: child),
+        if (isBlocking) ...[
+          const Positioned.fill(
+            child: ModalBarrier(dismissible: false, color: Color(0x66000000)),
+          ),
+          const Positioned.fill(
+            child: Center(child: CircularProgressIndicator()),
+          ),
+        ],
+      ],
+    );
+  }
+}

--- a/lib/features/home/presentation/helpers/main_shell_navigation_helpers.dart
+++ b/lib/features/home/presentation/helpers/main_shell_navigation_helpers.dart
@@ -1,0 +1,21 @@
+import '../../../../core/navigation/app_navigator.dart';
+
+class MainShellTabRequestAction {
+  final bool shouldSwitchTabs;
+  final bool shouldReloadCart;
+
+  const MainShellTabRequestAction({
+    required this.shouldSwitchTabs,
+    required this.shouldReloadCart,
+  });
+}
+
+MainShellTabRequestAction resolveMainShellTabRequest({
+  required int currentIndex,
+  required int requestedIndex,
+}) {
+  return MainShellTabRequestAction(
+    shouldSwitchTabs: currentIndex != requestedIndex,
+    shouldReloadCart: requestedIndex == AppNavigator.cartTab,
+  );
+}

--- a/lib/features/home/presentation/pages/main_shell.dart
+++ b/lib/features/home/presentation/pages/main_shell.dart
@@ -7,6 +7,7 @@ import '../../../category/presentation/pages/category_page.dart';
 import '../../../cart/presentation/pages/cart_page.dart';
 import '../../../cart/presentation/bloc/cart_bloc.dart';
 import '../../../auth/presentation/pages/account_page.dart';
+import '../helpers/main_shell_navigation_helpers.dart';
 import 'home_page.dart';
 
 /// Main Shell with bottom navigation bar — modern e-commerce navigation.
@@ -23,7 +24,8 @@ class MainShell extends StatefulWidget {
   const MainShell({super.key});
 
   /// GlobalKey for accessing MainShellState from anywhere in the app
-  static final GlobalKey<MainShellState> navigatorKey = GlobalKey<MainShellState>();
+  static final GlobalKey<MainShellState> navigatorKey =
+      GlobalKey<MainShellState>();
 
   @override
   State<MainShell> createState() => MainShellState();
@@ -38,16 +40,22 @@ class MainShellState extends State<MainShell> {
   final List<int> _tabHistory = [0]; // initial tab
 
   void switchToTab(int index) {
-    if (index == _currentIndex) return;
-    setState(() {
-      // Push current tab to history before switching
-      if (_tabHistory.isEmpty || _tabHistory.last != _currentIndex) {
-        _tabHistory.add(_currentIndex);
-      }
-      _currentIndex = index;
-    });
-    // Refresh cart data when switching to Cart tab
-    if (index == AppNavigator.cartTab) {
+    final action = resolveMainShellTabRequest(
+      currentIndex: _currentIndex,
+      requestedIndex: index,
+    );
+
+    if (action.shouldSwitchTabs) {
+      setState(() {
+        // Push current tab to history before switching
+        if (_tabHistory.isEmpty || _tabHistory.last != _currentIndex) {
+          _tabHistory.add(_currentIndex);
+        }
+        _currentIndex = index;
+      });
+    }
+
+    if (action.shouldReloadCart) {
       context.read<CartBloc>().add(LoadCart());
     }
   }
@@ -164,8 +172,8 @@ class MainShellState extends State<MainShell> {
               color: isActive
                   ? AppColors.primary500
                   : isDark
-                      ? AppColors.neutral300
-                      : AppColors.neutral800,
+                  ? AppColors.neutral300
+                  : AppColors.neutral800,
             ),
             const SizedBox(height: 2),
             Text(
@@ -177,8 +185,8 @@ class MainShellState extends State<MainShell> {
                 color: isActive
                     ? AppColors.primary500
                     : isDark
-                        ? AppColors.neutral300
-                        : AppColors.neutral800,
+                    ? AppColors.neutral300
+                    : AppColors.neutral800,
               ),
             ),
           ],
@@ -214,8 +222,8 @@ class MainShellState extends State<MainShell> {
                   color: isActive
                       ? AppColors.primary500
                       : isDark
-                          ? AppColors.neutral300
-                          : AppColors.neutral800,
+                      ? AppColors.neutral300
+                      : AppColors.neutral800,
                 ),
                 if (badgeCount > 0)
                   Positioned(
@@ -253,8 +261,8 @@ class MainShellState extends State<MainShell> {
                 color: isActive
                     ? AppColors.primary500
                     : isDark
-                        ? AppColors.neutral300
-                        : AppColors.neutral800,
+                    ? AppColors.neutral300
+                    : AppColors.neutral800,
               ),
             ),
           ],
@@ -262,5 +270,4 @@ class MainShellState extends State<MainShell> {
       ),
     );
   }
-
 }

--- a/test/account_address_input_test.dart
+++ b/test/account_address_input_test.dart
@@ -1,0 +1,65 @@
+import 'package:bagisto_flutter/features/account/data/models/account_models.dart';
+import 'package:bagisto_flutter/features/account/data/repository/account_repository.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  test(
+    'buildCustomerAddressMutationInput omits useForShipping for account add edit flow',
+    () {
+      final input = buildCustomerAddressMutationInput(
+        addressId: 42,
+        firstName: 'Jane',
+        lastName: 'Doe',
+        address: '221B Baker Street',
+        city: 'London',
+        state: 'LDN',
+        country: 'GB',
+        postcode: 'NW16XE',
+        phone: '+441234567890',
+        email: 'jane@example.com',
+        defaultAddress: true,
+      );
+
+      expect(input['addressId'], 42);
+      expect(input['defaultAddress'], isTrue);
+      expect(input['email'], 'jane@example.com');
+      expect(input.containsKey('useForShipping'), isFalse);
+    },
+  );
+
+  test(
+    'buildSetDefaultCustomerAddressMutationInput includes full address payload and omits useForShipping',
+    () {
+      final input = buildSetDefaultCustomerAddressMutationInput(
+        address: const CustomerAddress(
+          id: 'gid://bagisto/Address/42',
+          numericId: 42,
+          firstName: 'Jane',
+          lastName: 'Doe',
+          email: 'jane@example.com',
+          address: '221B Baker Street',
+          city: 'London',
+          state: 'LDN',
+          country: 'GB',
+          zipCode: 'NW16XE',
+          phone: '+441234567890',
+          isDefault: false,
+          useForShipping: false,
+        ),
+      );
+
+      expect(input['addressId'], 42);
+      expect(input['firstName'], 'Jane');
+      expect(input['lastName'], 'Doe');
+      expect(input['address1'], '221B Baker Street');
+      expect(input['city'], 'London');
+      expect(input['state'], 'LDN');
+      expect(input['country'], 'GB');
+      expect(input['postcode'], 'NW16XE');
+      expect(input['phone'], '+441234567890');
+      expect(input['email'], 'jane@example.com');
+      expect(input['defaultAddress'], isTrue);
+      expect(input.containsKey('useForShipping'), isFalse);
+    },
+  );
+}

--- a/test/account_dashboard_helper_test.dart
+++ b/test/account_dashboard_helper_test.dart
@@ -1,0 +1,73 @@
+import 'package:bagisto_flutter/features/account/data/models/account_models.dart';
+import 'package:bagisto_flutter/features/account/presentation/helpers/account_dashboard_helpers.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  group('resolveDashboardDefaultAddress', () {
+    test('returns null when address list is empty', () {
+      expect(resolveDashboardDefaultAddress(const []), isNull);
+    });
+
+    test('returns the default address when one exists', () {
+      const addresses = [
+        CustomerAddress(
+          firstName: 'First',
+          lastName: 'Address',
+          address: 'Street 1',
+          city: 'Noida',
+          state: 'UP',
+          country: 'IN',
+          zipCode: '201301',
+        ),
+        CustomerAddress(
+          firstName: 'Default',
+          lastName: 'Address',
+          address: 'Street 2',
+          city: 'Delhi',
+          state: 'DL',
+          country: 'IN',
+          zipCode: '110001',
+          isDefault: true,
+        ),
+      ];
+
+      expect(resolveDashboardDefaultAddress(addresses)?.firstName, 'Default');
+    });
+
+    test('falls back to the first address when none is default', () {
+      const addresses = [
+        CustomerAddress(
+          firstName: 'First',
+          lastName: 'Address',
+          address: 'Street 1',
+          city: 'Noida',
+          state: 'UP',
+          country: 'IN',
+          zipCode: '201301',
+        ),
+        CustomerAddress(
+          firstName: 'Second',
+          lastName: 'Address',
+          address: 'Street 2',
+          city: 'Delhi',
+          state: 'DL',
+          country: 'IN',
+          zipCode: '110001',
+        ),
+      ];
+
+      expect(resolveDashboardDefaultAddress(addresses)?.firstName, 'First');
+    });
+  });
+
+  test('refreshes dashboard after address book returns', () async {
+    var refreshCalls = 0;
+
+    await refreshAccountDashboardAfterAddressBook<void>(
+      openAddressBook: () async {},
+      onReturn: () => refreshCalls += 1,
+    );
+
+    expect(refreshCalls, 1);
+  });
+}

--- a/test/add_address_page_test.dart
+++ b/test/add_address_page_test.dart
@@ -1,0 +1,91 @@
+import 'package:bagisto_flutter/features/account/data/models/account_models.dart';
+import 'package:bagisto_flutter/features/account/data/repository/account_repository.dart';
+import 'package:bagisto_flutter/features/account/presentation/bloc/address_book_bloc.dart';
+import 'package:bagisto_flutter/features/account/presentation/pages/add_address_page.dart';
+import 'package:bagisto_flutter/l10n/app_localizations.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:graphql_flutter/graphql_flutter.dart';
+
+void main() {
+  testWidgets('account add address form shows only one Set as Default toggle', (
+    tester,
+  ) async {
+    await tester.pumpWidget(_buildTestApp());
+    await tester.pumpAndSettle();
+
+    expect(find.text('Set as Default'), findsOneWidget);
+    expect(find.text('Change default shipping address'), findsNothing);
+    expect(find.byType(Switch), findsOneWidget);
+  });
+
+  testWidgets(
+    'account edit address form also shows only one Set as Default toggle',
+    (tester) async {
+      await tester.pumpWidget(
+        _buildTestApp(
+          editingAddress: const CustomerAddress(
+            id: 'gid://bagisto/Address/42',
+            numericId: 42,
+            firstName: 'Jane',
+            lastName: 'Doe',
+            email: 'jane@example.com',
+            address: '221B Baker Street',
+            city: 'London',
+            state: 'LDN',
+            country: 'GB',
+            zipCode: 'NW16XE',
+            phone: '+441234567890',
+            isDefault: true,
+            useForShipping: false,
+          ),
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      expect(find.text('Set as Default'), findsOneWidget);
+      expect(find.text('Change default shipping address'), findsNothing);
+      expect(find.byType(Switch), findsOneWidget);
+    },
+  );
+}
+
+Widget _buildTestApp({CustomerAddress? editingAddress}) {
+  final repository = _FakeAccountRepository();
+
+  return RepositoryProvider<AccountRepository>.value(
+    value: repository,
+    child: MaterialApp(
+      locale: const Locale('en'),
+      localizationsDelegates: AppLocalizations.localizationsDelegates,
+      supportedLocales: AppLocalizations.supportedLocales,
+      home: BlocProvider(
+        create: (_) => AddressBookBloc(repository: repository),
+        child: AddAddressPage(editingAddress: editingAddress),
+      ),
+    ),
+  );
+}
+
+class _FakeAccountRepository extends AccountRepository {
+  _FakeAccountRepository()
+    : super(
+        client: GraphQLClient(
+          link: HttpLink('https://example.com/graphql'),
+          cache: GraphQLCache(store: InMemoryStore()),
+        ),
+      );
+
+  @override
+  Future<List<Country>> getCountries() async {
+    return const [
+      Country(id: '1', numericId: 826, code: 'GB', name: 'United Kingdom'),
+    ];
+  }
+
+  @override
+  Future<List<CountryState>> getCountryStates({required int countryId}) async {
+    return const [];
+  }
+}

--- a/test/address_book_navigation_helper_test.dart
+++ b/test/address_book_navigation_helper_test.dart
@@ -1,0 +1,33 @@
+import 'package:bagisto_flutter/features/account/presentation/helpers/address_book_navigation_helpers.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  test('refreshes address book when address form returns true', () async {
+    var refreshCalls = 0;
+
+    await refreshAddressBookAfterForm(
+      openForm: () async => true,
+      onSaved: () => refreshCalls += 1,
+    );
+
+    expect(refreshCalls, 1);
+  });
+
+  test(
+    'does not refresh address book when address form returns false or null',
+    () async {
+      var refreshCalls = 0;
+
+      await refreshAddressBookAfterForm(
+        openForm: () async => false,
+        onSaved: () => refreshCalls += 1,
+      );
+      await refreshAddressBookAfterForm(
+        openForm: () async => null,
+        onSaved: () => refreshCalls += 1,
+      );
+
+      expect(refreshCalls, 0);
+    },
+  );
+}

--- a/test/address_debug_payload_test.dart
+++ b/test/address_debug_payload_test.dart
@@ -1,0 +1,52 @@
+import 'package:bagisto_flutter/features/account/data/models/account_models.dart';
+import 'package:bagisto_flutter/features/account/presentation/utils/address_debug_payload.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  test(
+    'buildEditAddressDebugPayload includes saved address data and address id',
+    () {
+      const address = CustomerAddress(
+        id: 'gid://bagisto/Address/42',
+        numericId: 42,
+        firstName: 'Jane',
+        lastName: 'Doe',
+        email: 'jane@example.com',
+        companyName: 'Acme Corp',
+        vatId: 'VAT-42',
+        address: '221B Baker Street',
+        city: 'London',
+        state: 'LDN',
+        country: 'GB',
+        zipCode: 'NW16XE',
+        phone: '+441234567890',
+        isDefault: true,
+        useForShipping: false,
+        addressType: 'billing',
+        createdAt: '2026-05-25T10:00:00Z',
+      );
+
+      final payload = buildEditAddressDebugPayload(address);
+
+      expect(payload, {
+        'addressId': 42,
+        'id': 'gid://bagisto/Address/42',
+        'firstName': 'Jane',
+        'lastName': 'Doe',
+        'email': 'jane@example.com',
+        'companyName': 'Acme Corp',
+        'vatId': 'VAT-42',
+        'address': '221B Baker Street',
+        'city': 'London',
+        'state': 'LDN',
+        'country': 'GB',
+        'postcode': 'NW16XE',
+        'phone': '+441234567890',
+        'defaultAddress': true,
+        'useForShipping': false,
+        'addressType': 'billing',
+        'createdAt': '2026-05-25T10:00:00Z',
+      });
+    },
+  );
+}

--- a/test/address_state_field_behavior_test.dart
+++ b/test/address_state_field_behavior_test.dart
@@ -1,0 +1,22 @@
+import 'package:bagisto_flutter/features/account/presentation/utils/address_state_field_behavior.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  test(
+    'resolveStateFieldText preserves saved state text when country has no states',
+    () {
+      final value = resolveStateFieldText(
+        savedStateText: 'ghjgjgh',
+        matchedStateName: null,
+      );
+
+      expect(value, 'ghjgjgh');
+    },
+  );
+
+  test('shouldUseStateDropdown is false when country has no states', () {
+    final useDropdown = shouldUseStateDropdown(availableStateNames: const []);
+
+    expect(useDropdown, isFalse);
+  });
+}

--- a/test/checkout_address_sheet_test.dart
+++ b/test/checkout_address_sheet_test.dart
@@ -1,5 +1,6 @@
 import 'dart:async';
 
+import 'package:bagisto_flutter/features/cart/data/models/cart_model.dart';
 import 'package:bagisto_flutter/features/checkout/data/models/checkout_model.dart';
 import 'package:bagisto_flutter/features/checkout/data/repository/checkout_repository.dart';
 import 'package:bagisto_flutter/features/checkout/presentation/bloc/checkout_bloc.dart';
@@ -107,6 +108,143 @@ void main() {
   );
 
   test(
+    'loadChangeAddressSheetAddresses refreshes addresses for logged-in checkout',
+    () async {
+      var refreshCalls = 0;
+
+      final result = await loadChangeAddressSheetAddresses(
+        isGuest: false,
+        currentAddresses: const [],
+        refreshAddresses: () async {
+          refreshCalls += 1;
+          return const [
+            CheckoutAddress(
+              id: 'cust-1',
+              firstName: 'Saved',
+              lastName: 'Customer',
+            ),
+          ];
+        },
+      );
+
+      expect(refreshCalls, 1);
+      expect(result.single.id, 'cust-1');
+    },
+  );
+
+  test(
+    'loadChangeAddressSheetAddresses does not refresh for guest checkout',
+    () async {
+      var refreshCalls = 0;
+
+      final result = await loadChangeAddressSheetAddresses(
+        isGuest: true,
+        currentAddresses: const [
+          CheckoutAddress(
+            id: 'guest-form',
+            firstName: 'Guest',
+            lastName: 'User',
+          ),
+        ],
+        refreshAddresses: () async {
+          refreshCalls += 1;
+          return const [];
+        },
+      );
+
+      expect(refreshCalls, 0);
+      expect(result.single.id, 'guest-form');
+    },
+  );
+
+  test(
+    'confirmed logged-in checkout cards should refresh saved addresses before showing change sheet',
+    () {
+      expect(
+        shouldRefreshAddressesBeforeShowingChangeSheet(
+          isGuest: false,
+          addressConfirmed: true,
+        ),
+        isTrue,
+      );
+      expect(
+        shouldRefreshAddressesBeforeShowingChangeSheet(
+          isGuest: false,
+          addressConfirmed: false,
+        ),
+        isFalse,
+      );
+      expect(
+        shouldRefreshAddressesBeforeShowingChangeSheet(
+          isGuest: true,
+          addressConfirmed: true,
+        ),
+        isFalse,
+      );
+    },
+  );
+
+  test(
+    'InitCheckout respects checkout billing useForShipping and keeps checkout shipping address',
+    () async {
+      final repository = _FakeCheckoutRepository(
+        checkoutAddresses: const [
+          CheckoutAddress(
+            id: 'bill-1',
+            addressType: 'cart_billing',
+            firstName: 'Billing',
+            lastName: 'User',
+            address: 'Billing Street',
+            city: 'Noida',
+            state: 'UP',
+            country: 'IN',
+            postcode: '201001',
+            phone: '1111111111',
+            useForShipping: false,
+          ),
+          CheckoutAddress(
+            id: 'ship-1',
+            addressType: 'cart_shipping',
+            firstName: 'Shipping',
+            lastName: 'User',
+            address: 'Shipping Street',
+            city: 'Delhi',
+            state: 'DL',
+            country: 'IN',
+            postcode: '110001',
+            phone: '9999999999',
+          ),
+        ],
+        customerAddresses: const [],
+        shippingRates: const [],
+      );
+      final bloc = _SeededCheckoutBloc(repository: repository);
+
+      final emission = expectLater(
+        bloc.stream,
+        emitsThrough(
+          isA<CheckoutState>()
+              .having(
+                (state) => state.useSameAddressForShipping,
+                'same-address flag',
+                isFalse,
+              )
+              .having(
+                (state) => state.selectedShippingAddress?.id,
+                'selected shipping address id',
+                'ship-1',
+              ),
+        ),
+      );
+
+      bloc.add(const InitCheckout(cart: CartModel.empty, isGuest: false));
+
+      await emission;
+      await bloc.close();
+    },
+  );
+
+  test(
     'SelectSavedAddress includes separate shipping fields when shipping differs from billing',
     () async {
       final repository = _FakeCheckoutRepository(
@@ -163,6 +301,91 @@ void main() {
       expect(repository.lastSavedInput?['useForShipping'], isFalse);
       expect(repository.lastSavedInput?['shippingFirstName'], 'Shipping');
       expect(repository.lastSavedInput?['shippingCity'], 'Mumbai');
+      await bloc.close();
+    },
+  );
+
+  test(
+    'ToggleSameAddress auto-saves confirmed saved-address checkout when shipping changes',
+    () async {
+      final repository = _FakeCheckoutRepository(
+        checkoutAddresses: const [],
+        customerAddresses: const [],
+        shippingRates: const [],
+      );
+      final bloc = _SeededCheckoutBloc(repository: repository)
+        ..seedState(
+          const CheckoutState(
+            isGuest: false,
+            isVirtualOnly: false,
+            addressConfirmed: true,
+            useSameAddressForShipping: true,
+            selectedAddress: CheckoutAddress(
+              id: 'bill-1',
+              firstName: 'Billing',
+              lastName: 'User',
+              address: 'Billing Street',
+              city: 'Noida',
+              state: 'UP',
+              country: 'IN',
+              postcode: '201001',
+              phone: '1111111111',
+            ),
+            addresses: [
+              CheckoutAddress(
+                id: 'bill-1',
+                firstName: 'Billing',
+                lastName: 'User',
+                address: 'Billing Street',
+                city: 'Noida',
+                state: 'UP',
+                country: 'IN',
+                postcode: '201001',
+                phone: '1111111111',
+              ),
+              CheckoutAddress(
+                id: 'ship-1',
+                firstName: 'Shipping',
+                lastName: 'User',
+                address: 'Shipping Street',
+                city: 'Delhi',
+                state: 'DL',
+                country: 'IN',
+                postcode: '110001',
+                phone: '9999999999',
+              ),
+            ],
+          ),
+        );
+
+      final emission = expectLater(
+        bloc.stream,
+        emitsThrough(
+          isA<CheckoutState>()
+              .having(
+                (state) => state.addressConfirmed,
+                'address confirmed',
+                isTrue,
+              )
+              .having(
+                (state) => state.useSameAddressForShipping,
+                'same-address flag',
+                isFalse,
+              )
+              .having(
+                (state) => state.selectedShippingAddress?.id,
+                'selected shipping address id',
+                'ship-1',
+              ),
+        ),
+      );
+
+      bloc.add(ToggleSameAddress());
+
+      await emission;
+      expect(repository.lastSavedInput?['useForShipping'], isFalse);
+      expect(repository.lastSavedInput?['shippingFirstName'], 'Shipping');
+      expect(repository.lastSavedInput?['shippingCity'], 'Delhi');
       await bloc.close();
     },
   );
@@ -227,6 +450,86 @@ void main() {
     },
   );
 
+  test(
+    'SaveCheckoutAddressEvent saves separate billing and shipping addresses to the address book when requested',
+    () async {
+      final repository = _FakeCheckoutRepository(
+        checkoutAddresses: const [],
+        customerAddresses: const [],
+        shippingRates: const [],
+      );
+      final bloc = _SeededCheckoutBloc(repository: repository)
+        ..seedState(const CheckoutState(isGuest: false, isVirtualOnly: false));
+
+      final emission = expectLater(
+        bloc.stream,
+        emitsThrough(
+          isA<CheckoutState>().having(
+            (state) => state.addressConfirmed,
+            'address confirmed',
+            isTrue,
+          ),
+        ),
+      );
+
+      bloc.add(
+        const SaveCheckoutAddressEvent(
+          input: {
+            'billingFirstName': 'Billing',
+            'billingLastName': 'Customer',
+            'billingEmail': 'billing@example.com',
+            'billingAddress': 'Billing Street 1',
+            'billingCity': 'Noida',
+            'billingCountry': 'IN',
+            'billingState': 'UP',
+            'billingPostcode': '201301',
+            'billingPhoneNumber': '9999999999',
+            'shippingFirstName': 'Shipping',
+            'shippingLastName': 'Customer',
+            'shippingEmail': 'shipping@example.com',
+            'shippingAddress': 'Shipping Street 2',
+            'shippingCity': 'Delhi',
+            'shippingCountry': 'IN',
+            'shippingState': 'DL',
+            'shippingPostcode': '110001',
+            'shippingPhoneNumber': '8888888888',
+            'useForShipping': false,
+          },
+          saveToAddressBook: true,
+        ),
+      );
+
+      await emission;
+      expect(repository.createdCustomerAddressInputs, hasLength(2));
+      expect(
+        repository.createdCustomerAddressInputs[0]['firstName'],
+        'Billing',
+      );
+      expect(
+        repository.createdCustomerAddressInputs[0]['defaultAddress'],
+        isTrue,
+      );
+      expect(
+        repository.createdCustomerAddressInputs[0]['useForShipping'],
+        isFalse,
+      );
+      expect(
+        repository.createdCustomerAddressInputs[1]['firstName'],
+        'Shipping',
+      );
+      expect(
+        repository.createdCustomerAddressInputs[1]['defaultAddress'],
+        isFalse,
+      );
+      expect(
+        repository.createdCustomerAddressInputs[1]['useForShipping'],
+        isTrue,
+      );
+      expect(repository.createdCustomerAddressInputs[1]['city'], 'Delhi');
+      await bloc.close();
+    },
+  );
+
   testWidgets(
     'CheckoutAddressSelectionSheet shows Add New Address and calls callbacks',
     (WidgetTester tester) async {
@@ -255,7 +558,6 @@ void main() {
               selectedAddressId: 'addr-1',
               onAddressSelected: (address) => tappedAddress = address,
               onAddNewAddress: () => addTapped = true,
-              addressTypeLabelBuilder: (_) => 'Home',
               phoneLabelBuilder: (phone) => 'Phone: $phone',
             ),
           ),
@@ -274,6 +576,108 @@ void main() {
       expect(addTapped, isTrue);
     },
   );
+
+  test(
+    'SaveCheckoutAddressEvent keeps separate selected billing and shipping addresses for manual checkout input',
+    () async {
+      final repository = _FakeCheckoutRepository(
+        checkoutAddresses: const [],
+        customerAddresses: const [],
+        shippingRates: const [],
+      );
+      final bloc = _SeededCheckoutBloc(repository: repository)
+        ..seedState(const CheckoutState(isGuest: false, isVirtualOnly: false));
+
+      final emission = expectLater(
+        bloc.stream,
+        emitsThrough(
+          isA<CheckoutState>()
+              .having(
+                (state) => state.selectedAddress?.address,
+                'selected billing address',
+                'Billing Street 1',
+              )
+              .having(
+                (state) => state.selectedShippingAddress?.address,
+                'selected shipping address',
+                'Shipping Street 2',
+              )
+              .having(
+                (state) => state.useSameAddressForShipping,
+                'same-address flag',
+                isFalse,
+              ),
+        ),
+      );
+
+      bloc.add(
+        const SaveCheckoutAddressEvent(
+          input: {
+            'billingFirstName': 'Billing',
+            'billingLastName': 'Customer',
+            'billingEmail': 'billing@example.com',
+            'billingCompanyName': 'Billing Co',
+            'billingAddress': 'Billing Street 1',
+            'billingCity': 'Noida',
+            'billingCountry': 'IN',
+            'billingState': 'UP',
+            'billingPostcode': '201301',
+            'billingPhoneNumber': '9999999999',
+            'shippingFirstName': 'Shipping',
+            'shippingLastName': 'Customer',
+            'shippingEmail': 'shipping@example.com',
+            'shippingCompanyName': 'Shipping Co',
+            'shippingAddress': 'Shipping Street 2',
+            'shippingCity': 'Delhi',
+            'shippingCountry': 'IN',
+            'shippingState': 'DL',
+            'shippingPostcode': '110001',
+            'shippingPhoneNumber': '8888888888',
+            'useForShipping': false,
+          },
+          saveToAddressBook: true,
+        ),
+      );
+
+      await emission;
+      await bloc.close();
+    },
+  );
+
+  testWidgets(
+    'CheckoutAddressSelectionSheet does not show any address-type chip',
+    (WidgetTester tester) async {
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Scaffold(
+            body: CheckoutAddressSelectionSheet(
+              title: 'Select Billing Address',
+              addButtonLabel: 'Add New Address',
+              addresses: const [
+                CheckoutAddress(
+                  id: 'addr-1',
+                  firstName: 'Paul',
+                  lastName: 'Doe',
+                  address: 'New Noida',
+                  city: 'Noida',
+                  state: 'UP',
+                  country: 'IN',
+                  postcode: '201306',
+                ),
+              ],
+              selectedAddressId: 'addr-1',
+              onAddressSelected: (_) {},
+              onAddNewAddress: () {},
+              phoneLabelBuilder: (phone) => 'Phone: $phone',
+            ),
+          ),
+        ),
+      );
+
+      expect(find.text('Home'), findsNothing);
+      expect(find.text('Default'), findsNothing);
+    },
+  );
 }
 
 class _SeededCheckoutBloc extends CheckoutBloc {
@@ -290,6 +694,7 @@ class _FakeCheckoutRepository extends CheckoutRepository {
   final List<ShippingRate> shippingRates;
   Map<String, dynamic>? lastSavedInput;
   Map<String, dynamic>? lastCreatedCustomerAddressInput;
+  final List<Map<String, dynamic>> createdCustomerAddressInputs = [];
   late final List<CheckoutAddress> _customerAddresses;
 
   _FakeCheckoutRepository({
@@ -317,6 +722,9 @@ class _FakeCheckoutRepository extends CheckoutRepository {
       customerAddresses;
 
   @override
+  Future<List<BagistoCountry>> getCountries() async => <BagistoCountry>[];
+
+  @override
   Future<CheckoutAddressResponse> saveCheckoutAddress(
     Map<String, dynamic> input,
   ) async {
@@ -336,36 +744,32 @@ class _FakeCheckoutRepository extends CheckoutRepository {
     Map<String, dynamic> checkoutInput, {
     bool defaultAddress = false,
   }) async {
-    lastCreatedCustomerAddressInput = {
-      'firstName': checkoutInput['billingFirstName'],
-      'lastName': checkoutInput['billingLastName'],
-      'email': checkoutInput['billingEmail'],
-      'address': checkoutInput['billingAddress'],
-      'city': checkoutInput['billingCity'],
-      'state': checkoutInput['billingState'],
-      'country': checkoutInput['billingCountry'],
-      'postcode': checkoutInput['billingPostcode'],
-      'phone': checkoutInput['billingPhoneNumber'],
-      'defaultAddress': defaultAddress,
-      'useForShipping': checkoutInput['useForShipping'] == true,
-    };
-
-    _customerAddresses.add(
-      CheckoutAddress(
-        id: 'cust-${_customerAddresses.length + 1}',
-        addressType: 'home',
-        firstName: checkoutInput['billingFirstName']?.toString() ?? '',
-        lastName: checkoutInput['billingLastName']?.toString() ?? '',
-        address: checkoutInput['billingAddress']?.toString() ?? '',
-        city: checkoutInput['billingCity']?.toString() ?? '',
-        state: checkoutInput['billingState']?.toString(),
-        country: checkoutInput['billingCountry']?.toString(),
-        postcode: checkoutInput['billingPostcode']?.toString(),
-        email: checkoutInput['billingEmail']?.toString(),
-        phone: checkoutInput['billingPhoneNumber']?.toString(),
-        defaultAddress: defaultAddress,
-        useForShipping: checkoutInput['useForShipping'] == true,
-      ),
+    final inputs = buildCustomerAddressBookInputsFromCheckout(
+      checkoutInput,
+      defaultAddress: defaultAddress,
     );
+
+    for (final input in inputs) {
+      lastCreatedCustomerAddressInput = Map<String, dynamic>.from(input);
+      createdCustomerAddressInputs.add(lastCreatedCustomerAddressInput!);
+
+      _customerAddresses.add(
+        CheckoutAddress(
+          id: 'cust-${_customerAddresses.length + 1}',
+          addressType: 'home',
+          firstName: input['firstName']?.toString() ?? '',
+          lastName: input['lastName']?.toString() ?? '',
+          address: input['address1']?.toString() ?? '',
+          city: input['city']?.toString() ?? '',
+          state: input['state']?.toString(),
+          country: input['country']?.toString(),
+          postcode: input['postcode']?.toString(),
+          email: input['email']?.toString(),
+          phone: input['phone']?.toString(),
+          defaultAddress: input['defaultAddress'] == true,
+          useForShipping: input['useForShipping'] == true,
+        ),
+      );
+    }
   }
 }

--- a/test/checkout_flow_test.dart
+++ b/test/checkout_flow_test.dart
@@ -10,6 +10,7 @@
 import 'package:flutter_test/flutter_test.dart';
 import 'package:bagisto_flutter/features/cart/data/models/cart_model.dart';
 import 'package:bagisto_flutter/features/checkout/data/models/checkout_model.dart';
+import 'package:bagisto_flutter/features/checkout/data/repository/checkout_repository.dart';
 import 'package:bagisto_flutter/features/checkout/presentation/bloc/checkout_bloc.dart';
 
 void main() {
@@ -125,6 +126,14 @@ void main() {
       final response = CheckoutOrderResponse.fromJson(json);
 
       expect(response.success, true);
+    });
+  });
+
+  group('Checkout logging', () {
+    test('suppresses getCountries API detail logs only', () {
+      expect(shouldLogCheckoutOperation('getCountries'), isFalse);
+      expect(shouldLogCheckoutOperation('saveCheckoutAddress'), isTrue);
+      expect(shouldLogCheckoutOperation('getShippingRates'), isTrue);
     });
   });
 

--- a/test/checkout_interaction_blocker_test.dart
+++ b/test/checkout_interaction_blocker_test.dart
@@ -1,0 +1,57 @@
+import 'package:bagisto_flutter/features/checkout/presentation/widgets/checkout_interaction_blocker.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  testWidgets('allows taps when not blocking', (tester) async {
+    var tapCount = 0;
+
+    await tester.pumpWidget(
+      MaterialApp(
+        home: CheckoutInteractionBlocker(
+          isBlocking: false,
+          child: Scaffold(
+            body: Center(
+              child: ElevatedButton(
+                onPressed: () => tapCount++,
+                child: const Text('Tap me'),
+              ),
+            ),
+          ),
+        ),
+      ),
+    );
+
+    await tester.tap(find.text('Tap me'), warnIfMissed: false);
+    await tester.pump();
+
+    expect(tapCount, 1);
+    expect(find.byType(CircularProgressIndicator), findsNothing);
+  });
+
+  testWidgets('blocks taps and shows progress while blocking', (tester) async {
+    var tapCount = 0;
+
+    await tester.pumpWidget(
+      MaterialApp(
+        home: CheckoutInteractionBlocker(
+          isBlocking: true,
+          child: Scaffold(
+            body: Center(
+              child: ElevatedButton(
+                onPressed: () => tapCount++,
+                child: const Text('Tap me'),
+              ),
+            ),
+          ),
+        ),
+      ),
+    );
+
+    await tester.tap(find.text('Tap me'), warnIfMissed: false);
+    await tester.pump();
+
+    expect(tapCount, 0);
+    expect(find.byType(CircularProgressIndicator), findsOneWidget);
+  });
+}

--- a/test/default_addresses_section_test.dart
+++ b/test/default_addresses_section_test.dart
@@ -1,0 +1,51 @@
+import 'package:bagisto_flutter/features/account/data/models/account_models.dart';
+import 'package:bagisto_flutter/features/account/presentation/widgets/default_addresses_section.dart';
+import 'package:bagisto_flutter/l10n/app_localizations.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  testWidgets(
+    'shows only the resolved default address without billing or shipping labels',
+    (tester) async {
+      const addresses = [
+        CustomerAddress(
+          firstName: 'Billing',
+          lastName: 'Address',
+          address: 'Street 1',
+          city: 'Noida',
+          state: 'UP',
+          country: 'IN',
+          zipCode: '201301',
+        ),
+        CustomerAddress(
+          firstName: 'Primary',
+          lastName: 'User',
+          address: 'Street 2',
+          city: 'Delhi',
+          state: 'DL',
+          country: 'IN',
+          zipCode: '110001',
+          isDefault: true,
+        ),
+      ];
+
+      await tester.pumpWidget(
+        MaterialApp(
+          localizationsDelegates: AppLocalizations.localizationsDelegates,
+          supportedLocales: AppLocalizations.supportedLocales,
+          home: const Scaffold(
+            body: DefaultAddressesSection(addresses: addresses),
+          ),
+        ),
+      );
+
+      await tester.pumpAndSettle();
+
+      expect(find.text('Primary User'), findsOneWidget);
+      expect(find.text('Billing Address'), findsNothing);
+      expect(find.text('Shipping Address'), findsNothing);
+      expect(find.text('Default'), findsAtLeastNWidgets(1));
+    },
+  );
+}

--- a/test/main_shell_navigation_helper_test.dart
+++ b/test/main_shell_navigation_helper_test.dart
@@ -1,0 +1,38 @@
+import 'package:bagisto_flutter/core/navigation/app_navigator.dart';
+import 'package:bagisto_flutter/features/home/presentation/helpers/main_shell_navigation_helpers.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  test('re-requesting cart tab while already on cart still refreshes cart', () {
+    final action = resolveMainShellTabRequest(
+      currentIndex: AppNavigator.cartTab,
+      requestedIndex: AppNavigator.cartTab,
+    );
+
+    expect(action.shouldSwitchTabs, isFalse);
+    expect(action.shouldReloadCart, isTrue);
+  });
+
+  test(
+    'switching from another tab to cart both switches tabs and refreshes cart',
+    () {
+      final action = resolveMainShellTabRequest(
+        currentIndex: AppNavigator.accountTab,
+        requestedIndex: AppNavigator.cartTab,
+      );
+
+      expect(action.shouldSwitchTabs, isTrue);
+      expect(action.shouldReloadCart, isTrue);
+    },
+  );
+
+  test('switching to a non-cart tab does not trigger cart refresh', () {
+    final action = resolveMainShellTabRequest(
+      currentIndex: AppNavigator.homeTab,
+      requestedIndex: AppNavigator.categoriesTab,
+    );
+
+    expect(action.shouldSwitchTabs, isTrue);
+    expect(action.shouldReloadCart, isFalse);
+  });
+}


### PR DESCRIPTION
[Improvement] Improved account address state handling for countries without predefined states and preserved saved state values while editing addresses.
[Improvement] Simplified account address management with a single "Set as Default" flow and improved dashboard/address book refresh after add or edit actions.
[Improvement] Improved checkout saved-address synchronization, including refreshed address selection flows, separate billing and shipping selection handling, and interaction blocking while placing orders.
[Fixed] Fixed account default address updates by sending the full payload expected by the API.
[Fixed] Fixed checkout address book saving so separate billing and shipping addresses are preserved when they are different.
[Fixed] Fixed checkout address selection UI by removing address type badges and preserving separate shipping selections after manual address entry